### PR TITLE
Post Endpoint and Additive Imports

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -123,8 +123,9 @@ interface Api {
   // Non-Endpoint shared functions
   openFromDisk(datasetType: DatasetType | 'calibration' | 'annotation' | 'text' | 'zip', directory?: boolean):
     Promise<{canceled?: boolean; filePaths: string[]; fileList?: File[]; root?: string}>;
-  importAnnotationFile(id: string, path: string, file?: File): Promise<boolean>;
-}
+    importAnnotationFile(id: string, path: string, file?: File,
+      additive?: boolean, additivePrepend?: string): Promise<boolean>;
+  }
 const ApiSymbol = Symbol('api');
 
 /**

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -35,6 +35,8 @@ export default defineComponent({
     const { prompt } = usePrompt();
     const processing = ref(false);
     const menuOpen = ref(false);
+    const additive = ref(false);
+    const additivePrepend = ref('');
     const openUpload = async () => {
       try {
         const ret = await openFromDisk('annotation');
@@ -44,9 +46,21 @@ export default defineComponent({
           let importFile = false;
           processing.value = true;
           if (ret.fileList?.length) {
-            importFile = await importAnnotationFile(props.datasetId, path, ret.fileList[0]);
+            importFile = await importAnnotationFile(
+              props.datasetId,
+              path,
+              ret.fileList[0],
+              additive.value,
+              additivePrepend.value,
+            );
           } else {
-            importFile = await importAnnotationFile(props.datasetId, path);
+            importFile = await importAnnotationFile(
+              props.datasetId,
+              path,
+              undefined,
+              additive.value,
+              additivePrepend.value,
+            );
           }
 
           if (importFile) {
@@ -68,6 +82,9 @@ export default defineComponent({
       openUpload,
       processing,
       menuOpen,
+      additive,
+      additivePrepend,
+
     };
   },
 });
@@ -133,16 +150,33 @@ export default defineComponent({
             target="_blank"
           >Data Format Documentation</a>
         </v-card-text>
-        <v-card-actions>
-          <v-btn
-            depressed
-            block
-            :disabled="!datasetId || processing"
-            @click="openUpload"
-          >
-            Import
-          </v-btn>
-        </v-card-actions>
+        <v-container>
+          <v-col>
+            <v-row>
+              <v-btn
+                depressed
+                block
+                :disabled="!datasetId || processing"
+                @click="openUpload"
+              >
+                Import
+              </v-btn>
+            </v-row>
+            <v-row>
+              <v-switch
+                v-model="additive"
+                label="Additive"
+              />
+            </v-row>
+            <div v-if="additive">
+              <v-text-field
+                v-model="additivePrepend"
+                label="Prepend to types"
+                clearable
+              />
+            </div>
+          </v-col>
+        </v-container>
       </v-card>
     </template>
   </v-menu>

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "author": {
     "name": "Kitware, Inc.",
     "email": "viame-web@kitware.com"

--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -86,7 +86,7 @@ function makeViameFolder({
   );
 }
 
-async function importAnnotationFile(parentId: string, path: string, file?: HTMLFile) {
+async function importAnnotationFile(parentId: string, path: string, file?: HTMLFile, additive = false, additivePrepend = '') {
   if (file === undefined) {
     return false;
   }
@@ -108,7 +108,7 @@ async function importAnnotationFile(parentId: string, path: string, file?: HTMLF
       headers: { 'Content-Type': 'application/octet-stream' },
     });
     if (uploadResponse.status === 200) {
-      const final = await postProcess(parentId, true);
+      const final = await postProcess(parentId, true, false, additive, additivePrepend);
       return final.status === 200;
     }
   }

--- a/client/platform/web-girder/api/rpc.service.ts
+++ b/client/platform/web-girder/api/rpc.service.ts
@@ -1,8 +1,10 @@
 import girderRest from 'platform/web-girder/plugins/girder';
 
-function postProcess(folderId: string, skipJobs = false, skipTranscoding = false) {
+function postProcess(folderId: string, skipJobs = false, skipTranscoding = false, additive = false, additivePrepend = '') {
   return girderRest.post(`dive_rpc/postprocess/${folderId}`, null, {
-    params: { skipJobs, skipTranscoding },
+    params: {
+      skipJobs, skipTranscoding, additive, additivePrepend,
+    },
   });
 }
 

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -133,7 +133,9 @@ def _get_data_by_type(
     return None
 
 
-def process_items(folder: types.GirderModel, user: types.GirderUserModel):
+def process_items(
+    folder: types.GirderModel, user: types.GirderUserModel, additive=False, additivePrepend=''
+):
     """
     Discover unprocessed items in a dataset and process them by type in order of creation
     """
@@ -149,7 +151,10 @@ def process_items(folder: types.GirderModel, user: types.GirderUserModel):
         # Processing order: oldest to newest
         sort=[("created", pymongo.ASCENDING)],
     )
-    auxiliary = crud.get_or_create_auxiliary_folder(folder, user)
+    auxiliary = crud.get_or_create_auxiliary_folder(
+        folder,
+        user,
+    )
     for item in unprocessed_items:
         file: Optional[types.GirderModel] = next(Item().childFiles(item), None)
         if file is None:
@@ -171,10 +176,16 @@ def process_items(folder: types.GirderModel, user: types.GirderUserModel):
         item['meta'][constants.ProcessedMarker] = True
         Item().move(item, auxiliary)
         if results['annotations']:
+            updated_tracks = results['annotations']['tracks'].values()
+            if additive:  # get annotations and add them to the end
+                tracks = crud_annotation.add_annotations(
+                    folder, results['annotations']['tracks'], additivePrepend
+                )
+                updated_tracks = tracks.values()
             crud_annotation.save_annotations(
                 folder,
                 user,
-                upsert_tracks=results['annotations']['tracks'].values(),
+                upsert_tracks=updated_tracks,
                 upsert_groups=results['annotations']['groups'].values(),
                 overwrite=True,
                 description=f'Import {results["type"].name} from {file["name"]}',
@@ -186,7 +197,12 @@ def process_items(folder: types.GirderModel, user: types.GirderUserModel):
 
 
 def postprocess(
-    user: types.GirderUserModel, dsFolder: types.GirderModel, skipJobs: bool, skipTranscoding=False
+    user: types.GirderUserModel,
+    dsFolder: types.GirderModel,
+    skipJobs: bool,
+    skipTranscoding=False,
+    additive=False,
+    additivePrepend='',
 ) -> types.GirderModel:
     """
     Post-processing to be run after media/annotation import
@@ -294,5 +310,5 @@ def postprocess(
 
         Folder().save(dsFolder)
 
-    process_items(dsFolder, user)
+    process_items(dsFolder, user, additive, additivePrepend)
     return dsFolder

--- a/server/dive_server/views_rpc.py
+++ b/server/dive_server/views_rpc.py
@@ -58,9 +58,27 @@ class RpcResource(Resource):
             default=False,
             required=False,
         )
+        .param(
+            "additive",
+            "Whether to add new annotations to existing ones",
+            paramType="formData",
+            dataType="boolean",
+            default=False,
+            required=False,
+        )
+        .param(
+            "additivePrepend",
+            "When using additive the prepend to types: 'prepend_type'",
+            paramType="formData",
+            dataType="string",
+            default='',
+            required=False,
+        )
     )
-    def postprocess(self, folder, skipJobs, skipTranscoding):
-        return crud_rpc.postprocess(self.getCurrentUser(), folder, skipJobs, skipTranscoding)
+    def postprocess(self, folder, skipJobs, skipTranscoding, additive, additivePrepend):
+        return crud_rpc.postprocess(
+            self.getCurrentUser(), folder, skipJobs, skipTranscoding, additive, additivePrepend
+        )
 
     @access.user
     @autoDescribeRoute(


### PR DESCRIPTION
Adds the capability to do additive importing of CSV/trackJson files.

Also adds an endpoint  `PUT /dive_annotation/track` which will accept JSON data for creation of tracks.  Use the format:
```
{
  "tracks": [
    {
      "id": 1,
      "begin": 0,
      "end": 100,
      "confidencePairs": [["uploadedTrack", 1]],
      "attributes": {},
      "features": [
        {
          "frame": 0,
          "bounds": [10, 10, 500, 500],
          "attributes": {},
          "keyframe": true,
          "interpolate": true
        },
        {
          "frame": 100,
          "bounds": [100, 100, 800, 800],
          "attributes": {},
          "keyframe": true,
          "interpolate": true
        }
      ]
    }
  ]
}
```
above interpolate is set to true so the box will move between the two frames across the time series.