### PR TITLE
User Level Attributes

### DIFF
--- a/client/dive-common/components/AttributeEditor.vue
+++ b/client/dive-common/components/AttributeEditor.vue
@@ -31,6 +31,7 @@ export default defineComponent({
     const name: Ref<string> = ref(props.selectedAttribute.name);
     const belongs: Ref<string> = ref(props.selectedAttribute.belongs);
     const datatype: Ref<string> = ref(props.selectedAttribute.datatype);
+    const user: Ref<boolean | undefined> = ref(props.selectedAttribute.user);
     const color: Ref<string | undefined> = ref(props.selectedAttribute.color);
     const tempColor = ref(trackStyleManager.typeStyling.value.color(name.value));
     const areSettingsValid = ref(false);
@@ -83,6 +84,7 @@ export default defineComponent({
         editor: editor.value,
         color: color.value ? color.value : tempColor.value,
         shortcuts: shortcuts.value,
+        user: user.value ? true : undefined,
       };
 
       if (addNew) {
@@ -156,6 +158,7 @@ export default defineComponent({
       //computed
       textValues,
       shortcuts,
+      user,
       //functions
       add,
       submit,
@@ -221,6 +224,12 @@ export default defineComponent({
                 value="slider"
               />
             </v-radio-group>
+          </div>
+          <div>
+            <v-checkbox
+              v-model="user"
+              label="User Attribute"
+            />
           </div>
           <div v-if="datatype === 'number' && editor && editor.type === 'slider'">
             <v-row class="pt-2">

--- a/client/dive-common/components/AttributeEditor.vue
+++ b/client/dive-common/components/AttributeEditor.vue
@@ -195,7 +195,8 @@ export default defineComponent({
           <v-text-field
             v-model="name"
             label="Name"
-            :rules="[v => !!v || 'Name is required', v => !v.includes(' ') || 'No spaces']"
+            :rules="[v => !!v || 'Name is required', v => !v.includes(' ') ||
+              'No spaces', v => v !== 'userAttributes' || 'Reserved Name']"
             required
           />
           <v-select

--- a/client/dive-common/components/AttributeEditor.vue
+++ b/client/dive-common/components/AttributeEditor.vue
@@ -230,6 +230,8 @@ export default defineComponent({
             <v-checkbox
               v-model="user"
               label="User Attribute"
+              hint="Attribute data is saved per user instead of globally."
+              persistent-hint
             />
           </div>
           <div v-if="datatype === 'number' && editor && editor.type === 'slider'">

--- a/client/dive-common/components/AttributeUserReview.vue
+++ b/client/dive-common/components/AttributeUserReview.vue
@@ -1,0 +1,70 @@
+<script lang="ts">
+import {
+  defineComponent, ref, Ref, computed,
+} from '@vue/composition-api';
+
+import StackedVirtualSidebarContainer from 'dive-common/components/StackedVirtualSidebarContainer.vue';
+import { useAttributes, useCameraStore } from 'vue-media-annotator/provides';
+import AttributeSubsection from 'dive-common/components/AttributesSubsection.vue';
+
+export default defineComponent({
+  name: 'AttributeUserReview',
+
+  components: {
+    StackedVirtualSidebarContainer,
+    AttributeSubsection,
+  },
+
+  props: {
+    width: {
+      type: Number,
+      default: 300,
+    },
+  },
+
+  setup() {
+    const attributes = useAttributes();
+    const attributesList = computed(() => attributes.value.filter((item) => item.user === true));
+    const cameraStore = useCameraStore();
+    const userListData = cameraStore.getUserAttributeList();
+    const userList: Ref<string[]> = ref(Array.from(userListData));
+    return {
+      userList,
+      attributesList,
+      attributes,
+    };
+  },
+});
+</script>
+
+
+<template>
+  <StackedVirtualSidebarContainer
+    :width="width"
+    :enable-slot="false"
+  >
+    <template #default>
+      <v-container>
+        <v-row><h3> User Attribute Review</h3></v-row>
+        <div
+          v-for="user in userList"
+          :key="`userAttributes_${user}`"
+          class=""
+        >
+          <v-row><h4>{{ user }}:</h4></v-row>
+          <attribute-subsection
+            mode="Track"
+            :user="user"
+            :attributes="attributesList"
+          />
+          <attribute-subsection
+            mode="Detection"
+            :user="user"
+            :attributes="attributesList"
+          />
+          <v-divider />
+        </div>
+      </v-container>
+    </template>
+  </StackedVirtualSidebarContainer>
+</template>

--- a/client/dive-common/components/AttributesSubsection.vue
+++ b/client/dive-common/components/AttributesSubsection.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable max-len -->
 <script lang="ts">
 import {
   defineComponent,
@@ -169,9 +170,9 @@ export default defineComponent({
           return selectedAttributes.value.attributes[attribute.name];
         }
         const user = store.state.User.user?.login || null;
-        if (user && selectedAttributes.value.attributes[user]) {
-          if ((selectedAttributes.value.attributes[user] as StringKeyObject)[attribute.name]) {
-            return ((selectedAttributes.value.attributes[user] as StringKeyObject)[attribute.name]);
+        if (user && selectedAttributes.value.attributes?.userAttributes !== undefined && selectedAttributes.value.attributes.userAttributes[user]) {
+          if ((selectedAttributes.value.attributes.userAttributes[user] as StringKeyObject)[attribute.name]) {
+            return ((selectedAttributes.value.attributes.userAttributes[user] as StringKeyObject)[attribute.name]);
           }
         }
       }

--- a/client/dive-common/components/AttributesSubsection.vue
+++ b/client/dive-common/components/AttributesSubsection.vue
@@ -42,6 +42,10 @@ export default defineComponent({
       type: String as PropType<'Track' | 'Detection'>,
       required: true,
     },
+    user: {
+      type: String as PropType<string>,
+      default: '',
+    },
   },
   setup(props, { emit }) {
     const readOnlyMode = useReadOnlyMode();
@@ -121,7 +125,7 @@ export default defineComponent({
         const tracks = cameraStore.getTrackAll(selectedTrackIdRef.value);
         let user: null | string = null;
         if (attribute.user) {
-          user = store.state.User.user?.login || null;
+          user = props.user || store.state.User.user?.login || null;
         }
         if (tracks.length) {
           if (props.mode === 'Track') {
@@ -169,7 +173,7 @@ export default defineComponent({
         if (!attribute.user) {
           return selectedAttributes.value.attributes[attribute.name];
         }
-        const user = store.state.User.user?.login || null;
+        const user = props.user || store.state.User.user?.login || null;
         if (user && selectedAttributes.value.attributes?.userAttributes !== undefined && selectedAttributes.value.attributes.userAttributes[user]) {
           if ((selectedAttributes.value.attributes.userAttributes[user] as StringKeyObject)[attribute.name]) {
             return ((selectedAttributes.value.attributes.userAttributes[user] as StringKeyObject)[attribute.name]);
@@ -235,7 +239,7 @@ export default defineComponent({
           </div>
         </v-col>
         <v-tooltip
-          v-if="getUISetting('UIAttributeAdding')"
+          v-if="getUISetting('UIAttributeAdding') && user === ''"
           open-delay="200"
           bottom
           max-width="200"
@@ -256,6 +260,7 @@ export default defineComponent({
           <span>Add a new {{ mode }} Attribute</span>
         </v-tooltip>
         <v-tooltip
+          v-if="user === ''"
           open-delay="200"
           bottom
           max-width="200"
@@ -282,7 +287,7 @@ export default defineComponent({
           @click="clickSortToggle"
         />
         <tooltip-btn
-          v-if="getUISetting('UIAttributeDetails')"
+          v-if="getUISetting('UIAttributeDetails') && user === ''"
           icon="mdi-filter"
           :color="filtersActive ? 'primary' : 'default'"
           :tooltip-text="filtersActive
@@ -290,7 +295,7 @@ export default defineComponent({
           @click="openFilter"
         />
         <tooltip-btn
-          v-if="mode === 'Detection' && getUISetting('UIAttributeDetails')"
+          v-if="mode === 'Detection' && getUISetting('UIAttributeDetails') && user === ''"
           icon="mdi-chart-line-variant"
           :color="timelineActive ? 'primary' : 'default'"
           tooltip-text="Timeline Settings for Attributes"
@@ -374,7 +379,7 @@ export default defineComponent({
               cols="1"
             >
               <v-btn
-                v-if="getUISetting('UIAttributeSettings')"
+                v-if="getUISetting('UIAttributeSettings') && user === ''"
                 icon
                 x-small
                 @click="editAttribute(attribute)"

--- a/client/dive-common/components/Sidebar.vue
+++ b/client/dive-common/components/Sidebar.vue
@@ -89,7 +89,7 @@ export default defineComponent({
       ];
       if (!readOnlyMode.value && !multiCam) {
         trap.push(
-          { bind: 'm', handler: doToggleMerge },
+          { bind: 'm', handler: () => getUISetting('UIEditing') && doToggleMerge() },
           { bind: 'g', handler: () => { groupAdd(); data.currentTab = 'attributes'; } },
           { bind: 'shift+m', handler: commitMerge },
         );

--- a/client/dive-common/components/TrackDetailsPanel.vue
+++ b/client/dive-common/components/TrackDetailsPanel.vue
@@ -202,7 +202,7 @@ export default defineComponent({
         {
           bind: 'del',
           handler: () => {
-            if (!readOnlyMode.value && selectedTrackIdRef.value !== null) {
+            if (!readOnlyMode.value && selectedTrackIdRef.value !== null && getUISetting('UIEditing')) {
               removeTrack([selectedTrackIdRef.value]);
             }
           },

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -49,6 +49,7 @@ import context from 'dive-common/store/context';
 import { UISettingsKey } from 'vue-media-annotator/ConfigurationManager';
 import ImageEnhancementsVue from 'vue-media-annotator/components/ImageEnhancements.vue';
 import RevisionHistoryVue from 'platform/web-girder/views/RevisionHistory.vue';
+import { useStore } from 'platform/web-girder/store/types';
 import AttributeShortcutToggle from './AttributeShortcutToggle.vue';
 import GroupSidebarVue from './GroupSidebar.vue';
 import MultiCamToolsVue from './MultiCamTools.vue';
@@ -146,6 +147,8 @@ export default defineComponent({
       }
       return 'track';
     });
+
+    const store = useStore();
 
     const {
       save: saveToServer,
@@ -256,6 +259,7 @@ export default defineComponent({
       selectedTrackId,
       cameraStore,
       pendingSaveCount,
+      login: store.state.User.user?.login || '',
     });
 
 

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -1030,7 +1030,7 @@ export default defineComponent({
           v-mousetrap="[
             { bind: 'n', handler: () => !readonlyState && handler.trackAdd() },
             { bind: 'r', handler: () => aggregateController.resetZoom() },
-            { bind: 'esc', handler: () => handler.trackAbort() },
+            { bind: 'esc', handler: () => getUISetting('UISelection') && handler.trackAbort() },
           ]"
           class="d-flex flex-column grow"
         >

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -56,6 +56,7 @@ import MultiCamToolsVue from './MultiCamTools.vue';
 import PrevNext from './PrevNext.vue';
 import AttributesSideBarVue from './AttributesSideBar.vue';
 import TypeThresholdVue from './TypeThreshold.vue';
+import AttributeUserReviewVue from './AttributeUserReview.vue';
 
 export interface ImageDataItem {
   url: string;
@@ -661,6 +662,12 @@ export default defineComponent({
           context.unregister({
             description: 'Attrbute Details',
             component: AttributesSideBarVue,
+          });
+        }
+        if (!configurationManager.getUISetting('UIAttributeUserReview')) {
+          context.unregister({
+            description: 'Attrbute User Review',
+            component: AttributeUserReviewVue,
           });
         }
         if (!configurationManager.getUISetting('UIThresholdControls')) {

--- a/client/dive-common/components/configurationEditors/UISettings/UIInteractions.vue
+++ b/client/dive-common/components/configurationEditors/UISettings/UIInteractions.vue
@@ -1,0 +1,56 @@
+<script lang="ts">
+import {
+  defineComponent, ref, watch,
+} from '@vue/composition-api';
+import { useConfiguration } from 'vue-media-annotator/provides';
+
+
+export default defineComponent({
+  name: 'UIInteractions',
+  components: {
+  },
+  setup() {
+    const configMan = useConfiguration();
+    const UISelection = ref(configMan.getUISetting('UISelection') as boolean);
+    const UIEditing = ref(configMan.getUISetting('UIEditing') as boolean);
+
+    watch([UISelection, UIEditing], () => {
+      const data = {
+        UISelection: UISelection.value ? undefined : false,
+        UIEditing: UIEditing.value ? undefined : false,
+      };
+      configMan.setUISettings('UIInteractions', data);
+    });
+    return {
+      UISelection,
+      UIEditing,
+    };
+  },
+
+});
+</script>
+
+<template>
+  <v-card>
+    <v-card-title>Context Bar (Right side) Settings</v-card-title>
+    <v-card-text>
+      <div>
+        <v-row dense>
+          <v-switch
+            v-model="UISelection"
+            label="UI Selecting/Deselecting"
+          />
+        </v-row>
+        <v-row dense>
+          <v-switch
+            v-model="UIEditing"
+            label="UI Editing Annotations"
+          />
+        </v-row>
+      </div>
+    </v-card-text>
+  </v-card>
+</template>
+
+<style lang="scss">
+</style>

--- a/client/dive-common/components/configurationEditors/UISettings/UISideBar.vue
+++ b/client/dive-common/components/configurationEditors/UISettings/UISideBar.vue
@@ -18,14 +18,16 @@ export default defineComponent({
     const UITrackDetails = ref(configMan.getUISetting('UITrackDetails') as boolean);
     const UIAttributeSettings = ref(configMan.getUISetting('UIAttributeSettings') as boolean);
     const UIAttributeAdding = ref(configMan.getUISetting('UIAttributeAdding') as boolean);
+    const UIAttributeUserReview = ref(configMan.getUISetting('UIAttributeUserReview') as boolean);
 
-    watch([UITrackTypes, UIConfidenceThreshold, UITrackList, UITrackDetails, UIAttributeSettings, UIAttributeAdding], () => {
+    watch([UITrackTypes, UIConfidenceThreshold, UITrackList, UITrackDetails, UIAttributeSettings, UIAttributeAdding, UIAttributeUserReview], () => {
       const data = {
         UITrackTypes: UITrackTypes.value ? undefined : false,
         UIConfidenceThreshold: UIConfidenceThreshold.value ? undefined : false,
         UITrackList: UITrackList.value ? undefined : false,
         UIAttributeSettings: UIAttributeSettings.value ? undefined : false,
         UIAttributeAdding: UIAttributeAdding.value ? undefined : false,
+        UIAttributeUserReview: UIAttributeUserReview.value ? undefined : false,
 
       };
       configMan.setUISettings('UISideBar', data);
@@ -37,6 +39,7 @@ export default defineComponent({
       UITrackDetails,
       UIAttributeSettings,
       UIAttributeAdding,
+      UIAttributeUserReview,
     };
   },
 
@@ -82,6 +85,12 @@ export default defineComponent({
           <v-switch
             v-model="UIAttributeAdding"
             label="Adding Attributes"
+          />
+        </v-row>
+        <v-row dense>
+          <v-switch
+            v-model="UIAttributeUserReview"
+            label="Attribute User Review"
           />
         </v-row>
       </div>

--- a/client/dive-common/components/configurationEditors/uiSettings.vue
+++ b/client/dive-common/components/configurationEditors/uiSettings.vue
@@ -4,6 +4,7 @@ import {
 } from '@vue/composition-api';
 import { Configuration, UISettings } from 'vue-media-annotator/ConfigurationManager';
 import { useConfiguration } from 'vue-media-annotator/provides';
+import UIInteractionsVue from './UISettings/UIInteractions.vue';
 import UITopBarVue from './UISettings/UITopBar.vue';
 import UIToolBarVue from './UISettings/UIToolBar.vue';
 import UIContextBarVue from './UISettings/UIContextBar.vue';
@@ -15,6 +16,7 @@ import UITrackDetailsVue from './UISettings/UITrackDetails.vue';
 export default defineComponent({
   name: 'uiSettings',
   components: {
+    'ui-interactions': UIInteractionsVue,
     'ui-top-bar': UITopBarVue,
     'ui-tool-bar': UIToolBarVue,
     'ui-context-bar': UIContextBarVue,
@@ -35,6 +37,7 @@ export default defineComponent({
     const UITrackDetails = ref(configMan.getUISetting('UITrackDetails') as boolean);
     const UIControls = ref(configMan.getUISetting('UIControls') as boolean);
     const UITimeline = ref(configMan.getUISetting('UITimeline') as boolean);
+    const UIInteractions = ref(configMan.getUISetting('UIInteractions') as boolean);
 
     const launchEditor = () => {
       generalDialog.value = true;
@@ -61,6 +64,7 @@ export default defineComponent({
         UITrackDetails: setVal('UITrackDetails', UITrackDetails.value),
         UIControls: setVal('UIControls', UIControls.value),
         UITimeline: setVal('UITimeline', UITimeline.value),
+        UIInteractions: setVal('UIInteractions', UIInteractions.value),
 
       };
       configMan.setRootUISettings(data as UISettings);
@@ -77,6 +81,7 @@ export default defineComponent({
       generalDialog,
       launchEditor,
       saveChanges,
+      UIInteractions,
       UITopBar,
       UIToolBar,
       UISideBar,
@@ -127,6 +132,9 @@ export default defineComponent({
           <v-card-title class="text-h6">
             <v-tabs v-model="currentTab">
               <v-tab> Main </v-tab>
+              <v-tab :disabled="!UIInteractions">
+                Interactions
+              </v-tab>
               <v-tab :disabled="!UITopBar">
                 TopBar
               </v-tab>
@@ -152,6 +160,13 @@ export default defineComponent({
           </v-card-title>
           <v-tabs-items v-model="currentTab">
             <v-tab-item>
+              <v-row dense>
+                <v-switch
+                  v-model="UIInteractions"
+                  label="Interactions"
+                />
+              </v-row>
+
               <v-row dense>
                 <v-switch
                   v-model="UITopBar"
@@ -195,6 +210,9 @@ export default defineComponent({
                   label="Timeline"
                 />
               </v-row>
+            </v-tab-item>
+            <v-tab-item>
+              <ui-interactions />
             </v-tab-item>
             <v-tab-item>
               <ui-top-bar />

--- a/client/dive-common/store/context.ts
+++ b/client/dive-common/store/context.ts
@@ -5,6 +5,7 @@ import TypeThreshold from 'dive-common/components/TypeThreshold.vue';
 import ImageEnhancements from 'vue-media-annotator/components/ImageEnhancements.vue';
 import GroupSidebar from 'dive-common/components/GroupSidebar.vue';
 import AttributesSideBar from 'dive-common/components/AttributesSideBar.vue';
+import AtributeUserReview from 'dive-common/components/AttributeUserReview.vue';
 import MultiCamTools from 'dive-common/components/MultiCamTools.vue';
 
 Vue.use(Install);
@@ -46,6 +47,10 @@ const componentMap: Record<string, ComponentMapItem> = {
   [AttributesSideBar.name]: {
     description: 'Attribute Details',
     component: AttributesSideBar,
+  },
+  [AtributeUserReview.name]: {
+    description: 'Attribute User Review',
+    component: AtributeUserReview,
   },
 };
 

--- a/client/dive-common/use/usedShortcuts.ts
+++ b/client/dive-common/use/usedShortcuts.ts
@@ -9,7 +9,7 @@ const usedShortcuts = [
   { key: 'x', description: 'Split Track' },
   { key: 'n', description: 'New Track' },
   { key: 'r', description: 'Reset Zoom' },
-  { key: 'esc', description: 'Abort Track Cration' },
+  { key: 'esc', description: 'Abort Track Creation' },
   { key: 'h', description: 'Head First Point' },
   { key: 't', description: 'Tail First Point' },
   { key: 'k', description: 'Toggle Keyframe' },

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "author": {
     "name": "Kitware, Inc.",
     "email": "viame-web@kitware.com"

--- a/client/platform/web-girder/main.ts
+++ b/client/platform/web-girder/main.ts
@@ -38,7 +38,7 @@ if (
 
 Promise.all([
   store.dispatch('Brand/loadBrand'),
-  girderRest.fetchUser(),
+  store.dispatch('User/loadUser'),
 ]).then(() => {
   const vuetify = getVuetify(store.state.Brand.brandData?.vuetify);
   Vue.use(promptService(vuetify));

--- a/client/platform/web-girder/store/User.ts
+++ b/client/platform/web-girder/store/User.ts
@@ -1,0 +1,26 @@
+import { merge } from 'lodash';
+import { Module } from 'vuex';
+
+import type { UserState, RootState } from './types';
+import girderRest from '../plugins/girder';
+
+
+const userModule: Module<UserState, RootState> = {
+  namespaced: true,
+  state: {
+    user: null,
+  },
+  mutations: {
+    setUserState(state, data: UserState) {
+      state.user = merge(state.user, data);
+    },
+  },
+  actions: {
+    async loadUser({ commit }) {
+      const data = await girderRest.fetchUser();
+      commit('setUserState', data);
+    },
+  },
+};
+
+export default userModule;

--- a/client/platform/web-girder/store/index.ts
+++ b/client/platform/web-girder/store/index.ts
@@ -6,6 +6,7 @@ import { RootState } from './types';
 import Location from './Location';
 import Dataset from './Dataset';
 import Brand from './Brand';
+import User from './User';
 import Jobs, { init as JobsInit } from './Jobs';
 
 Vue.use(Vuex);
@@ -13,6 +14,7 @@ Vue.use(Vuex);
 const store = new Vuex.Store<RootState>({
   modules: {
     Brand,
+    User,
     Location,
     Dataset,
     Jobs,

--- a/client/platform/web-girder/store/types.ts
+++ b/client/platform/web-girder/store/types.ts
@@ -29,6 +29,18 @@ export interface BrandState {
   brandData: BrandData;
 }
 
+export interface UserState {
+  user: null | {
+    admin: boolean;
+    email: string;
+    firstName: string;
+    login: string;
+    lastName: string;
+    status: string;
+  };
+}
+
+
 export interface JobState {
   jobIds: Record<string, number>;
   datasetStatus: Record<string, {status: number; jobId: string}>;
@@ -39,6 +51,7 @@ export interface RootState {
   Location: LocationState;
   Dataset: DatasetState;
   Brand: BrandState;
+  User: UserState;
 }
 
 export function useStore(): Store<RootState> {

--- a/client/src/BaseAnnotation.ts
+++ b/client/src/BaseAnnotation.ts
@@ -15,7 +15,7 @@ export interface StringKeyObject {
 export interface BaseData {
   id: AnnotationId;
   meta?: StringKeyObject;
-  attributes: StringKeyObject;
+  attributes: StringKeyObject & { userAttributes?: StringKeyObject };
   confidencePairs: Array<ConfidencePair>;
   begin: number;
   end: number;
@@ -27,7 +27,7 @@ export interface BaseAnnotationParams {
   begin?: number;
   end?: number;
   confidencePairs?: Array<ConfidencePair>;
-  attributes?: StringKeyObject;
+  attributes?: StringKeyObject & { userAttributes?: StringKeyObject };
 }
 
 /**
@@ -39,7 +39,7 @@ export default abstract class BaseAnnotation {
 
   meta?: StringKeyObject;
 
-  attributes: StringKeyObject;
+  attributes: StringKeyObject & { userAttributes?: StringKeyObject };
 
   confidencePairs: ConfidencePair[];
 
@@ -160,11 +160,16 @@ export default abstract class BaseAnnotation {
   setAttribute(key: string, value: unknown, user: null | string = null) {
     let oldval = this.attributes[key];
     if (user !== null) {
-      if (this.attributes[user] === undefined) {
-        this.attributes[user] = {};
+      if (this.attributes.userAttributes === undefined) {
+        this.attributes.userAttributes = {};
       }
-      oldval = (this.attributes[user] as StringKeyObject);
-      (this.attributes[user] as StringKeyObject)[key] = value;
+      if (this.attributes.userAttributes[user] === undefined) {
+        this.attributes.userAttributes[user] = {};
+      }
+      oldval = (this.attributes.userAttributes[user] as StringKeyObject);
+      (this.attributes.userAttributes[user] as StringKeyObject)[key] = value;
+    } else {
+      this.attributes[key] = value;
     }
     this.notify('attributes', { key, value: oldval });
   }

--- a/client/src/BaseAnnotation.ts
+++ b/client/src/BaseAnnotation.ts
@@ -157,9 +157,15 @@ export default abstract class BaseAnnotation {
     this.notify('confidencePairs', old);
   }
 
-  setAttribute(key: string, value: unknown) {
-    const oldval = this.attributes[key];
-    this.attributes[key] = value;
+  setAttribute(key: string, value: unknown, user: null | string = null) {
+    let oldval = this.attributes[key];
+    if (user !== null) {
+      if (this.attributes[user] === undefined) {
+        this.attributes[user] = {};
+      }
+      oldval = (this.attributes[user] as StringKeyObject);
+      (this.attributes[user] as StringKeyObject)[key] = value;
+    }
     this.notify('attributes', { key, value: oldval });
   }
 

--- a/client/src/CameraStore.ts
+++ b/client/src/CameraStore.ts
@@ -272,4 +272,15 @@ export default class CameraStore {
         });
       });
     }
+
+    getUserAttributeList() {
+      let userList = new Set<string>();
+
+      this.camMap.value.forEach((camera) => {
+        camera.trackStore.annotationMap.forEach((store) => {
+          userList = new Set([...userList, ...store.getUserAttributeList()]);
+        });
+      });
+      return userList;
+    }
 }

--- a/client/src/ConfigurationManager.ts
+++ b/client/src/ConfigurationManager.ts
@@ -90,6 +90,11 @@ interface UITimeline {
     UIEvents? : boolean;
 }
 
+interface UIInteractions {
+  UISelection?: boolean;
+  UIEditing?: boolean;
+}
+
 export interface UISettings {
     UITopBar?: boolean | UITopBar;
     UIToolBar?: boolean | UIToolBar;
@@ -98,13 +103,15 @@ export interface UISettings {
     UITrackDetails?: boolean | UITrackDetails;
     UIControls?: boolean | UIControls;
     UITimeline?: boolean | UITimeline;
+    UIInteractions?: boolean | UIInteractions;
 
 }
 export type UISettingsKey = keyof UISettings | keyof UITopBar | keyof UIToolBar
-| keyof UISideBar | keyof UIContextBar | keyof UITrackDetails | keyof UIControls | keyof UITimeline;
+| keyof UISideBar | keyof UIContextBar | keyof UITrackDetails | keyof UIControls
+| keyof UITimeline | keyof UIInteractions;
 
 type UIValue = UITopBar | UIToolBar
-| UISideBar | UIContextBar | UITrackDetails | UIControls | UITimeline;
+| UISideBar | UIContextBar | UITrackDetails | UIControls | UITimeline | UIInteractions;
 
 export interface Configuration {
   general?: {
@@ -279,6 +286,7 @@ export default class ConfigurationManager {
         UITrackDetails: true,
         UIControls: true,
         UITimeline: true,
+        UIInteractions: true,
       };
     }
     if (this.configuration.value?.UISettings) {

--- a/client/src/ConfigurationManager.ts
+++ b/client/src/ConfigurationManager.ts
@@ -54,6 +54,7 @@ interface UISideBar {
     UITrackDetails? : boolean;
     UIAttributeSettings? : boolean;
     UIAttributeAdding? : boolean;
+    UIAttributeUserReview?: boolean;
 
 }
 

--- a/client/src/TrackStore.ts
+++ b/client/src/TrackStore.ts
@@ -14,4 +14,12 @@ export default class TrackStore extends BaseAnnotationStore<Track> {
     this.markChangesPending({ action: 'upsert', track, cameraName: this.cameraName });
     return track;
   }
+
+  getUserAttributeList() {
+    let userList = new Set<string>();
+    this.annotationMap.forEach((item) => {
+      userList = new Set([...userList, ...item.getUserAttributeList()]);
+    });
+    return userList;
+  }
 }

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -5,7 +5,8 @@ import {
 import { difference, union } from 'lodash';
 
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
-import { useReadOnlyMode } from '../provides';
+import { UISettingsKey } from 'vue-media-annotator/ConfigurationManager';
+import { useConfiguration, useReadOnlyMode } from '../provides';
 import TooltipBtn from './TooltipButton.vue';
 import TypeEditor from './TypeEditor.vue';
 import TypeItem from './TypeItem.vue';
@@ -60,7 +61,8 @@ export default defineComponent({
   setup(props) {
     const { prompt } = usePrompt();
     const readOnlyMode = useReadOnlyMode();
-
+    const configMan = useConfiguration();
+    const getUISetting = (key: UISettingsKey) => (configMan.getUISetting(key));
     // Ordering of these lists should match
     const sortingMethods = ['a-z', 'count'];
     const sortingMethodIcons = ['mdi-sort-alphabetical-ascending', 'mdi-sort-numeric-ascending'];
@@ -230,6 +232,7 @@ export default defineComponent({
       headCheckClicked,
       setCheckedTypes: trackFilters.updateCheckedTypes,
       updateCheckedType,
+      getUISetting,
     };
   },
 });
@@ -273,6 +276,7 @@ export default defineComponent({
           >
             <template #activator="{ on }">
               <v-btn
+                v-if="getUISetting('UIEditing')"
                 class="hover-show-child"
                 :disabled="checkedTypesRef.length === 0 || readOnlyMode"
                 icon

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -3,6 +3,7 @@ import {
   defineComponent, watch, PropType, Ref, ref, computed, toRef,
 } from '@vue/composition-api';
 
+import { UISettingsKey } from 'vue-media-annotator/ConfigurationManager';
 import { TrackWithContext } from '../BaseFilterControls';
 import { injectAggregateController } from './annotators/useMediaController';
 import RectangleLayer from '../layers/AnnotationLayers/RectangleLayer';
@@ -33,6 +34,7 @@ import {
   useGroupStyleManager,
   useCameraStore,
   useSelectedCamera,
+  useConfiguration,
 } from '../provides';
 
 /** LayerManager is a component intended to be used as a child of an Annotator.
@@ -60,6 +62,9 @@ export default defineComponent({
     const handler = useHandler();
     const cameraStore = useCameraStore();
     const selectedCamera = useSelectedCamera();
+    const configMan = useConfiguration();
+    const getUISetting = (key: UISettingsKey) => (configMan.getUISetting(key));
+
     const trackStore = cameraStore.camMap.value.get(props.camera)?.trackStore;
     const groupStore = cameraStore.camMap.value.get(props.camera)?.groupStore;
     if (!trackStore || !groupStore) {
@@ -346,9 +351,10 @@ export default defineComponent({
         return;
       }
       //So we only want to pass the click whjen not in creation mode or editing mode for features
-      if (editAnnotationLayer.getMode() !== 'creation') {
+      if (editAnnotationLayer.getMode() !== 'creation' && getUISetting('UISelection')) {
         editAnnotationLayer.disable();
-        handler.trackSelect(trackId, editing);
+        const editTrack = editing && getUISetting('UIEditing') as boolean;
+        handler.trackSelect(trackId, editTrack);
       }
     };
 

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -237,8 +237,8 @@ export default defineComponent({
         <span
           v-show="false"
           v-mousetrap="[
-            { bind: 'k', handler: toggleKeyframe},
-            { bind: 'i', handler: toggleInterpolation},
+            { bind: 'k', handler: () => getUISetting('UIEditing') && toggleKeyframe()},
+            { bind: 'i', handler: () => getUISetting('UIEditing') && toggleInterpolation()},
             { bind: 'home', handler: () => $emit('seek', track.begin)},
             { bind: 'end', handler: () => $emit('seek', track.end)},
           ]"

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -3,10 +3,11 @@ import {
   defineComponent, computed, PropType, ref,
 } from '@vue/composition-api';
 import context from 'dive-common/store/context';
+import { UISettingsKey } from 'vue-media-annotator/ConfigurationManager';
 import TooltipBtn from './TooltipButton.vue';
 import TypePicker from './TypePicker.vue';
 import {
-  useHandler, useTime, useReadOnlyMode, useTrackFilters, useCameraStore,
+  useHandler, useTime, useReadOnlyMode, useTrackFilters, useCameraStore, useConfiguration,
 } from '../provides';
 import Track from '../track';
 
@@ -66,6 +67,8 @@ export default defineComponent({
     const allTypesRef = trackFilters.allTypes;
     const readOnlyMode = useReadOnlyMode();
     const cameraStore = useCameraStore();
+    const configMan = useConfiguration();
+    const getUISetting = (key: UISettingsKey) => (configMan.getUISetting(key));
     const multiCam = ref(cameraStore.camMap.value.size > 1);
     /**
      * Use of revision is safe because it will only create a
@@ -170,6 +173,7 @@ export default defineComponent({
       toggleInterpolation,
       toggleKeyframe,
       setTrackType,
+      getUISetting,
     };
   },
 });
@@ -210,7 +214,7 @@ export default defineComponent({
           <div
             class="trackNumber pl-0 pr-2"
             v-on="on"
-            @click.self="handler.trackSeek(track.trackId)"
+            @click.self="getUISetting('UISelection') && handler.trackSeek(track.trackId)"
           >
             {{ track.trackId }}
           </div>
@@ -240,6 +244,7 @@ export default defineComponent({
           ]"
         />
         <tooltip-btn
+          v-if="getUISetting('UIEditing')"
           color="error"
           icon="mdi-delete"
           :disabled="merging || readOnlyMode"
@@ -248,7 +253,7 @@ export default defineComponent({
         />
         <span v-if="!multiCam">
           <tooltip-btn
-            v-if="isTrack"
+            v-if="isTrack && getUISetting('UIEditing')"
             :disabled="!track.canSplit(frame) || merging || readOnlyMode"
             icon="mdi-call-split"
             tooltip-text="Split Track"
@@ -256,7 +261,7 @@ export default defineComponent({
           />
 
           <tooltip-btn
-            v-if="isTrack && !readOnlyMode"
+            v-if="isTrack && !readOnlyMode && getUISetting('UIEditing')"
             :icon="(feature.isKeyframe)
               ? 'mdi-star'
               : 'mdi-star-outline'"
@@ -266,7 +271,7 @@ export default defineComponent({
           />
 
           <tooltip-btn
-            v-if="isTrack && !readOnlyMode"
+            v-if="isTrack && !readOnlyMode && getUISetting('UIEditing')"
             :icon="(feature.shouldInterpolate)
               ? 'mdi-vector-selection'
               : 'mdi-selection-off'"
@@ -316,7 +321,7 @@ export default defineComponent({
       />
 
       <tooltip-btn
-        v-if="!merging"
+        v-if="!merging && getUISetting('UIEditing')"
         :icon="(editing) ? 'mdi-pencil-box' : 'mdi-pencil-box-outline'"
         tooltip-text="Toggle edit mode"
         :disabled="!inputValue || readOnlyMode"

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -165,14 +165,18 @@ export default defineComponent({
         {
           bind: 'up',
           handler: (el: HTMLElement, event: KeyboardEvent) => {
-            virtualScroll.scrollPreventDefault(el, event, 'up');
+            if (getUISetting('UISelection')) {
+              virtualScroll.scrollPreventDefault(el, event, 'up');
+            }
           },
           disabled,
         },
         {
           bind: 'down',
           handler: (el: HTMLElement, event: KeyboardEvent) => {
-            virtualScroll.scrollPreventDefault(el, event, 'down');
+            if (getUISetting('UISelection')) {
+              virtualScroll.scrollPreventDefault(el, event, 'down');
+            }
           },
           disabled,
         },

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -5,6 +5,7 @@ import {
 
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { AnnotationId } from 'vue-media-annotator/BaseAnnotation';
+import { UISettingsKey } from 'vue-media-annotator/ConfigurationManager';
 
 import {
   useEditingMode,
@@ -16,6 +17,7 @@ import {
   useTrackStyleManager,
   useMultiSelectList,
   useCameraStore,
+  useConfiguration,
 } from '../provides';
 import useVirtualScrollTo from '../use/useVirtualScrollTo';
 import TrackItem from './TrackItem.vue';
@@ -59,6 +61,9 @@ export default defineComponent({
     const checkedTrackIdsRef = trackFilters.checkedIDs;
     const editingModeRef = useEditingMode();
     const selectedTrackIdRef = useSelectedTrackId();
+    const configMan = useConfiguration();
+    const getUISetting = (key: UISettingsKey) => (configMan.getUISetting(key));
+
     const cameraStore = useCameraStore();
     const filteredTracksRef = trackFilters.filteredAnnotations;
     const typeStylingRef = useTrackStyleManager().typeStyling;
@@ -174,7 +179,7 @@ export default defineComponent({
         {
           bind: 'del',
           handler: () => {
-            if (!readOnlyMode.value && selectedTrackIdRef.value !== null) {
+            if (!readOnlyMode.value && selectedTrackIdRef.value !== null && getUISetting('UIEditing')) {
               removeTrack([selectedTrackIdRef.value]);
             }
           },
@@ -204,6 +209,7 @@ export default defineComponent({
       virtualListItems,
       virtualList: virtualScroll.virtualList,
       multiDelete,
+      getUISetting,
     };
   },
 });
@@ -217,6 +223,7 @@ export default defineComponent({
           Tracks ({{ filteredTracks.length }})
           <v-spacer />
           <v-menu
+            v-if="getUISetting('UIEditing')"
             v-model="data.settingsActive"
             :close-on-content-click="false"
             :nudge-bottom="28"
@@ -243,11 +250,13 @@ export default defineComponent({
             />
           </v-menu>
           <v-tooltip
+            v-if="getUISetting('UIEditing')"
             open-delay="100"
             bottom
           >
             <template #activator="{ on }">
               <v-btn
+
                 :disabled="filteredTracks.length === 0 || readOnlyMode"
                 icon
                 small
@@ -266,6 +275,7 @@ export default defineComponent({
             <span>Delete visible items</span>
           </v-tooltip>
           <v-tooltip
+            v-if="getUISetting('UIEditing')"
             open-delay="200"
             bottom
             max-width="200"

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import { RectBounds } from './utils';
 import {
   binarySearch,
@@ -24,7 +25,7 @@ export interface Feature {
   bounds?: RectBounds;
   geometry?: GeoJSON.FeatureCollection<TrackSupportedFeature>;
   fishLength?: number;
-  attributes?: StringKeyObject;
+  attributes?: StringKeyObject & { userAttributes?: StringKeyObject };
   head?: [number, number];
   tail?: [number, number];
 }
@@ -355,12 +356,13 @@ export default class Track extends BaseAnnotation {
         this.features[frame].attributes = {
           ...this.features[frame].attributes,
         };
-        if (this.features[frame].attributes !== undefined) {
-          (this.features[frame].attributes as StringKeyObject)[user] = {
-            ...(this.features[frame].attributes as StringKeyObject)[user] as StringKeyObject,
-            [name]: value,
-          };
+        if (this.features[frame].attributes !== undefined && (this.features[frame].attributes as StringKeyObject).userAttributes === undefined) {
+          (this.features[frame].attributes as StringKeyObject).userAttributes = {};
         }
+        ((this.features[frame].attributes as StringKeyObject).userAttributes as StringKeyObject)[user] = {
+          ...(this.features[frame].attributes as StringKeyObject)[user] as StringKeyObject,
+          [name]: value,
+        };
       } else {
         this.features[frame].attributes = {
           ...this.features[frame].attributes,

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -441,6 +441,21 @@ export default class Track extends BaseAnnotation {
     return features;
   }
 
+  getUserAttributeList() {
+    const userList = new Set<string>();
+    if (this.attributes && this.attributes.userAttributes) {
+      Object.keys(this.attributes.userAttributes).forEach((item) => userList.add(item));
+    }
+    if (this.features) {
+      this.features.forEach((feature) => {
+        if (feature.attributes && feature.attributes.userAttributes) {
+          Object.keys(feature.attributes.userAttributes).forEach((item) => userList.add(item));
+        }
+      });
+    }
+    return userList;
+  }
+
   /* Serialize back to a regular track object */
   serialize(): TrackData {
     return {

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -349,12 +349,24 @@ export default class Track extends BaseAnnotation {
   }
 
 
-  setFeatureAttribute(frame: number, name: string, value: unknown) {
+  setFeatureAttribute(frame: number, name: string, value: unknown, user: null | string = null) {
     if (this.features[frame]) {
-      this.features[frame].attributes = {
-        ...this.features[frame].attributes,
-        [name]: value,
-      };
+      if (user !== null) {
+        this.features[frame].attributes = {
+          ...this.features[frame].attributes,
+        };
+        if (this.features[frame].attributes !== undefined) {
+          (this.features[frame].attributes as StringKeyObject)[user] = {
+            ...(this.features[frame].attributes as StringKeyObject)[user] as StringKeyObject,
+            [name]: value,
+          };
+        }
+      } else {
+        this.features[frame].attributes = {
+          ...this.features[frame].attributes,
+          [name]: value,
+        };
+      }
       this.notify('feature', this.features[frame]);
     }
   }

--- a/client/src/use/useAttributes.ts
+++ b/client/src/use/useAttributes.ts
@@ -49,6 +49,7 @@ export interface Attribute {
   name: string;
   key: string;
   color?: string;
+  user?: boolean;
   editor?: NumericAttributeEditorOptions | StringAttributeEditorOptions;
   shortcuts?: AttributeShortcut[];
 }
@@ -513,7 +514,7 @@ export default function UseAttributes(
   });
 
   const timelineDefault = computed(() => {
-    const defVal = Object.entries(timelineGraphs.value).find(([key, item]) => item.default);
+    const defVal = Object.entries(timelineGraphs.value).find(([_key, item]) => item.default);
     if (defVal) {
       return defVal[0];
     }

--- a/client/src/use/useAttributes.ts
+++ b/client/src/use/useAttributes.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 
 import {
   ref, Ref, computed, set as VueSet, del as VueDel,
@@ -127,6 +128,7 @@ interface UseAttributesParams {
   trackStyleManager: StyleManager;
   cameraStore: CameraStore;
   pendingSaveCount: Ref<number>;
+  login: string;
 }
 
 export default function UseAttributes(
@@ -136,6 +138,7 @@ export default function UseAttributes(
     selectedTrackId,
     cameraStore,
     pendingSaveCount,
+    login,
   }: UseAttributesParams,
 ) {
   const attributes: Ref<Record<string, Attribute>> = ref({});
@@ -369,7 +372,14 @@ export default function UseAttributes(
       if (feature.attributes) {
         Object.keys(feature.attributes).forEach((key) => {
           if (feature.attributes && (filter.appliedTo.includes(key) || filter.appliedTo.includes('all'))) {
-            const val = feature.attributes[key] as string | number | boolean | undefined;
+            let val: string | number | boolean | undefined;
+            // Get user attribute if it exists:
+            const baseAttribute = attributesList.value.find((item) => item.name === key);
+            if (baseAttribute?.user && feature.attributes.userAttributes) {
+              val = feature.attributes.userAttributes[login] as string | number | boolean | undefined;
+            } else {
+              val = feature.attributes[key] as string | number | boolean | undefined;
+            }
             if (val === undefined) {
               return;
             }

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -268,6 +268,7 @@ class UISideBar(BaseModel):
     UITrackDetails: Optional[bool]
     UIAttributeSettings: Optional[bool]
     UIAttributeAdding: Optional[bool]
+    UIAttributeUserReview: Optional[bool]
 
 
 class UIContextBar(BaseModel):

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -158,13 +158,15 @@ class Attribute(BaseModel):
     editor: Optional[Union[NumericAttributeOptions, StringAttributeOptions]]
     shortcuts: Optional[List[ShortcutAttributeOptions]]
 
+
 class AttributeNumberFilter(BaseModel):
     type: Literal['range', 'top']
-    comp: Literal['>' ,'<', '>=', '<=']
+    comp: Literal['>', '<', '>=', '<=']
     value: float
     active: bool
     range: List[float]
     appliedTo: List[str]
+
 
 class AttributeKeyFilter(BaseModel):
     appliedTo: List[str]
@@ -172,11 +174,13 @@ class AttributeKeyFilter(BaseModel):
     value: bool
     type: Literal['key']
 
+
 class AttributeBoolFilter(BaseModel):
     value: bool
     type: Literal['is', 'not']
     appliedTo: List[str]
     active: bool
+
 
 class AttributeStringFilter(BaseModel):
     comp: Literal['=', '!=', 'contains', 'starts']
@@ -188,7 +192,10 @@ class AttributeStringFilter(BaseModel):
 class AttributeFilter(BaseModel):
     belongsTo: Literal['track', 'detection']
     dataType: Literal['text', 'number', 'boolean', 'key']
-    filterData: Union[AttributeKeyFilter, AttributeStringFilter, AttributeBoolFilter, AttributeNumberFilter]
+    filterData: Union[
+        AttributeKeyFilter, AttributeStringFilter, AttributeBoolFilter, AttributeNumberFilter
+    ]
+
 
 class TimeLineGraphSettings(BaseModel):
     type: Literal['Linear', 'Step', 'StepAfter', 'StepBefore', 'Natural']
@@ -206,6 +213,7 @@ class TimeLineGraph(BaseModel):
     default: Optional[bool]
     settings: Optional[Dict[str, TimeLineGraphSettings]]
 
+
 class CustomStyle(BaseModel):
     color: Optional[str]
     strokeWidth: Optional[float]
@@ -213,6 +221,7 @@ class CustomStyle(BaseModel):
     fill: Optional[bool]
     showLabel: Optional[bool]
     showConfidence: Optional[bool]
+
 
 class ConfigurationSettings(BaseModel):
     addTypes: Optional[bool]
@@ -244,11 +253,13 @@ class UITopBar(BaseModel):
     UIKeyboardShortcuts: Optional[bool]
     UISave: Optional[bool]
 
+
 class UIToolBar(BaseModel):
     UIEditingInfo: Optional[bool]
     UIEditingTypes: Optional[List[bool]]  # Rectangle, Polygon, Line by default
     UIVisibility: Optional[List[bool]]  # Rectnagle, Polygon, Line by default
     UITrackTrails: Optional[bool]
+
 
 class UISideBar(BaseModel):
     UITrackTypes: Optional[bool]
@@ -258,6 +269,7 @@ class UISideBar(BaseModel):
     UIAttributeSettings: Optional[bool]
     UIAttributeAdding: Optional[bool]
 
+
 class UIContextBar(BaseModel):
     UIThresholdControls: Optional[bool]
     UIImageEnhancements: Optional[bool]
@@ -265,12 +277,14 @@ class UIContextBar(BaseModel):
     UIAttributeDetails: Optional[bool]
     UIRevisionHistory: Optional[bool]
 
+
 class UITrackDetails(BaseModel):
     UITrackBrowser: Optional[bool]
     UITrackMerge: Optional[bool]
     UIConfidencePairs: Optional[bool]
     UITrackAttributes: Optional[bool]
     UIDetectionAttributes: Optional[bool]
+
 
 class UIControls(BaseModel):
     UIPlaybackControls: Optional[bool]
@@ -281,9 +295,11 @@ class UIControls(BaseModel):
     UIImageNameDisplay: Optional[bool]
     UILockCamera: Optional[bool]
 
+
 class UITimeline(BaseModel):
     UIDetections: Optional[bool]
     UIEvents: Optional[bool]
+
 
 class UISettings(BaseModel):
     UITopBar: Optional[Union[bool, UITopBar]]
@@ -294,13 +310,16 @@ class UISettings(BaseModel):
     UIControls: Optional[Union[bool, UIControls]]
     UITimeline: Optional[Union[bool, UITimeline]]
 
+
 class AttributeMatch(BaseModel):
     op: Optional[Literal['=', '!=', '>', '<', '>=', '<=', 'range', 'in']]
     val: Any
 
+
 class AttributeSelectAction(BaseModel):
     track: Optional[Dict[str, AttributeMatch]]
     detection: Optional[Dict[str, AttributeMatch]]
+
 
 class TrackSelectAction(BaseModel):
     typeFilter: Optional[List[str]]
@@ -311,22 +330,27 @@ class TrackSelectAction(BaseModel):
     type: Optional[Literal['TrackSelection']]
     direction: Optional[Literal['next', 'previous']]
 
+
 class GoToFrameAction(BaseModel):
     track: Optional[TrackSelectAction]
     frame: Optional[int]
     type: Literal['GoToFrame']
 
+
 class DIVEActions(BaseModel):
     action: Union[GoToFrameAction, TrackSelectAction]
+
 
 class ShortCut(BaseModel):
     key: str
     modifiers: Optional[List[str]]
 
+
 class DIVEShortcut(BaseModel):
     shortcut: ShortCut
     description: str
     actions: List[DIVEActions]
+
 
 class DIVEConfiguration(BaseModel):
     general: Optional[GeneralSettings]

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -301,6 +301,9 @@ class UITimeline(BaseModel):
     UIDetections: Optional[bool]
     UIEvents: Optional[bool]
 
+class UIInteractions(BaseModel):
+    UISelection: Optional[bool]
+    UIEditing: Optional[bool]
 
 class UISettings(BaseModel):
     UITopBar: Optional[Union[bool, UITopBar]]
@@ -310,6 +313,7 @@ class UISettings(BaseModel):
     UITrackDetails: Optional[Union[bool, UITrackDetails]]
     UIControls: Optional[Union[bool, UIControls]]
     UITimeline: Optional[Union[bool, UITimeline]]
+    UIInteractions: Optional[Union[bool, UIInteractions]]
 
 
 class AttributeMatch(BaseModel):

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -154,6 +154,7 @@ class Attribute(BaseModel):
     name: str
     key: str
     color: Optional[str]
+    user: Optional[bool]
     editor: Optional[Union[NumericAttributeOptions, StringAttributeOptions]]
     shortcuts: Optional[List[ShortcutAttributeOptions]]
 


### PR DESCRIPTION
resolves #30 

- Adds an option to make attribute 'User' level.  This will allow storage of frame and track level attributes in a special Key: 'userAttributes' for each attribute field.
- Adds a User Store to the Vuex State to store the user login name and other information.
- When a user attribute is set or requested it will be stored under the user login name in the `userAttribute` key so multiple users can set attribute values and not have them conflict with each other.
- There is now a User Attribute Review which will list the attributes that are set to 'user' and will display their names and values for each frame.  This is a capability to review user attributes in the system.
- Added in Attribute User Review to the sidebar to make it so you can hide User Attribute Reviewing
- Added in UIInteractions to turn off editing and track selection through the configuration as well.
