### PR TITLE
resize timeline, shortcut, and fix deletion error

### DIFF
--- a/client/dive-common/components/UserGuideDialog.vue
+++ b/client/dive-common/components/UserGuideDialog.vue
@@ -27,6 +27,9 @@ export default defineComponent({
             {
               name: 'Select Track', icon: 'mdi-keyboard', actions: ['Up/Down Arrows'], description: 'Select Track',
             },
+            {
+              name: 'Toggle Timeline', icon: 'mdi-keyboard', actions: ['Shift + T'], description: 'Collapse/Expand Timeline',
+            },
           ],
         },
         {

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -797,6 +797,10 @@ export default defineComponent({
       if (controlsRef.value) observer.unobserve(controlsRef.value.$el);
     });
 
+    const updateTimelineHeight = async () => {
+      await nextTick();
+      handleResize();
+    };
     const globalHandler = {
       ...handler,
       save,
@@ -927,6 +931,7 @@ export default defineComponent({
       save,
       saveThreshold,
       updateTime,
+      updateTimelineHeight,
       // multicam
       multiCamList,
       defaultCamera,
@@ -1152,6 +1157,7 @@ export default defineComponent({
             :collapsed.sync="controlsCollapsed"
             v-bind="{ lineChartData, eventChartData, groupChartData, datasetType }"
             @select-track="handler.trackSelect"
+            @timeline-height="updateTimelineHeight()"
           />
         </div>
         <div

--- a/client/dive-common/components/configurationEditors/TimelineConfiguration.vue
+++ b/client/dive-common/components/configurationEditors/TimelineConfiguration.vue
@@ -147,7 +147,7 @@ export default defineComponent({
       :key="timeline.name"
       dense
     >
-      <v-col>
+      <v-col cols="3">
         {{ timeline.name }}
       </v-col>
       <v-col>

--- a/client/dive-common/use/usedShortcuts.ts
+++ b/client/dive-common/use/usedShortcuts.ts
@@ -3,6 +3,7 @@ const usedShortcuts = [
   { key: 'a', description: 'Attribute Tab' },
   { key: 'm', description: 'Group Add' },
   { key: 'shift+m', description: 'Commit Merge' },
+  { key: 'shift+t', description: 'Collapse/Expand Timeline' },
   { key: 'up', description: 'Select Previous Track' },
   { key: 'down', description: 'Select Next Track' },
   { key: 'delete', description: 'Delete Track' },

--- a/client/src/ConfigurationManager.ts
+++ b/client/src/ConfigurationManager.ts
@@ -456,8 +456,7 @@ export default class ConfigurationManager {
       if (timelines.length === 1) {
         this.configuration.value.timelineConfigs.timelines = [];
       } else if (timelines[index]) {
-        const newTimelines = timelines.splice(index, 1);
-        this.configuration.value.timelineConfigs.timelines = newTimelines;
+        timelines.splice(index, 1);
       }
     }
   }

--- a/client/src/components/AttributeLineGraph.vue
+++ b/client/src/components/AttributeLineGraph.vue
@@ -48,6 +48,7 @@ export default defineComponent({
     const originalDefault = props.timelineGraph.default || false;
     const editTimelineName = ref(props.timelineGraph.name || 'default');
     const yRange = ref([-1, -1]);
+    const ticks = ref(-1);
     const filterNames = computed(() => {
       const data = ['all'];
       return data.concat(attributesList.value.filter((item) => item.belongs === 'detection' && item.datatype === 'number').map((item) => item.name));
@@ -70,6 +71,7 @@ export default defineComponent({
         enabled: editTimelineEnabled.value,
         settings: editTimelineSettings.value,
         yRange: yRange.value,
+        ticks: ticks.value,
         default: setDefault,
       };
       setTimelineGraph(editTimelineName.value, updateObject);
@@ -155,6 +157,7 @@ export default defineComponent({
       showGraphSettings,
       editTimelineKey,
       yRange,
+      ticks,
       showRangeSettings,
     };
   },
@@ -361,6 +364,14 @@ export default defineComponent({
             v-model.number="yRange[1]"
             type="number"
             label="Max"
+            hint="-1 will auto calculate"
+            persistent-hint
+            class="mx-2"
+          />
+          <v-text-field
+            v-model.number="ticks"
+            type="number"
+            label="Ticks"
             hint="-1 will auto calculate"
             persistent-hint
           />

--- a/client/src/components/AttributeLineGraph.vue
+++ b/client/src/components/AttributeLineGraph.vue
@@ -47,8 +47,8 @@ export default defineComponent({
     const originalName = props.timelineGraph.name;
     const originalDefault = props.timelineGraph.default || false;
     const editTimelineName = ref(props.timelineGraph.name || 'default');
-    const yRange = ref([-1, -1]);
-    const ticks = ref(-1);
+    const yRange = ref(props.timelineGraph.yRange || [-1, -1]);
+    const ticks = ref(props.timelineGraph.ticks || -1);
     const filterNames = computed(() => {
       const data = ['all'];
       return data.concat(attributesList.value.filter((item) => item.belongs === 'detection' && item.datatype === 'number').map((item) => item.name));

--- a/client/src/components/controls/LineChart.vue
+++ b/client/src/components/controls/LineChart.vue
@@ -30,6 +30,10 @@ export default Vue.extend({
       type: Array,
       default: () => [-1, -1],
     },
+    ticks: {
+      type: Number,
+      default: () => -1,
+    },
     margin: {
       type: Number,
       default: 0,
@@ -52,6 +56,7 @@ export default Vue.extend({
       adjustRange: false,
       tempRange: [-1, -1],
       currentRange: [-1, -1],
+      currentTicks: -1,
     };
   },
   computed: {
@@ -82,7 +87,15 @@ export default Vue.extend({
       this.initialize();
       this.update();
     },
+    ticks() {
+      this.initialize();
+      this.update();
+    },
     currentRange() {
+      this.initialize();
+      this.update();
+    },
+    currentTicks() {
       this.initialize();
       this.update();
     },
@@ -96,6 +109,7 @@ export default Vue.extend({
   methods: {
     initialize() {
       this.currentRange = this.yRange;
+      this.currentTicks = this.ticks;
       d3.select(this.$el)
         .select('svg')
         .remove();
@@ -148,6 +162,9 @@ export default Vue.extend({
         .attr('transform', 'translate(0,-1)');
 
       const axis = d3.axisRight(y).tickSize(width);
+      if (this.currentTicks > 0) {
+        axis.ticks(this.currentTicks);
+      }
       svg
         .append('g')
         .attr('class', 'axis-y')
@@ -342,6 +359,15 @@ export default Vue.extend({
               v-model.number="currentRange[1]"
               type="number"
               label="Max"
+              hint="-1 will auto calculate"
+              persistent-hint
+            />
+          </v-row>
+          <v-row>
+            <v-text-field
+              v-model.number="currentTicks"
+              type="number"
+              label="Tick Count"
               hint="-1 will auto calculate"
               persistent-hint
             />

--- a/client/src/components/controls/LineChart.vue
+++ b/client/src/components/controls/LineChart.vue
@@ -128,7 +128,7 @@ export default Vue.extend({
       this.x = x;
       const maxVal = d3.max(this.data, (datum) => d3.max(datum.values, (d) => d[1]));
       const minVal = d3.min(this.data, (datum) => d3.min(datum.values, (d) => d[1]));
-      let max = maxVal;
+      let max = maxVal * 1.10;
       let min = minVal;
       if (this.currentRange !== undefined) {
         if (this.currentRange[0] !== -1) {
@@ -146,7 +146,7 @@ export default Vue.extend({
       if (this.atrributesChart) {
         y = d3
           .scaleLinear()
-          .domain([min, Math.max(max * 1.2, 1.0)])
+          .domain([min, Math.max(max * 1.0, 1.0)])
           .range([height, 0]);
       }
 

--- a/client/src/components/controls/LineChart.vue
+++ b/client/src/components/controls/LineChart.vue
@@ -105,11 +105,11 @@ export default Vue.extend({
   },
   mounted() {
     this.initialize();
+    this.currentTicks = this.ticks;
   },
   methods: {
     initialize() {
       this.currentRange = this.yRange;
-      this.currentTicks = this.ticks;
       d3.select(this.$el)
         .select('svg')
         .remove();

--- a/client/src/components/controls/Timeline.vue
+++ b/client/src/components/controls/Timeline.vue
@@ -56,6 +56,11 @@ export default {
     },
   },
   watch: {
+    timelineHeight() {
+      this.$nextTick(() => {
+        this.initialize();
+      });
+    },
     maxFrame(value) {
       this.endFrame = value;
       this.init = true;

--- a/client/src/components/controls/TimelineCharts.vue
+++ b/client/src/components/controls/TimelineCharts.vue
@@ -124,7 +124,7 @@ export default defineComponent({
 
     const attributeDataTimeline = computed(() => {
       const data: {
-        startFrame: number; endFrame: number; data: LineChartData[]; yRange?: number[];
+        startFrame: number; endFrame: number; data: LineChartData[]; yRange?: number[]; ticks?: number;
       }[] = [];
       Object.entries(attributeTimelineData.value).forEach(([key, timelineData]) => {
         if (timelineEnabled.value[key]) {
@@ -136,6 +136,7 @@ export default defineComponent({
             endFrame,
             data: timelineChartData,
             yRange: timelineData.yRange,
+            ticks: timelineData.ticks,
           });
         }
       });
@@ -272,6 +273,7 @@ export default defineComponent({
               :client-width="clientWidth"
               :client-height="getTimelineHeight(timeline)"
               :y-range="data.yRange"
+              :ticks="data.ticks || -1"
               :margin="margin"
               :class="{'timeline-config': timelineList.length}"
               :atrributes-chart="true"
@@ -403,6 +405,7 @@ export default defineComponent({
             :client-width="clientWidth"
             :client-height="clientHeight"
             :y-range="data.yRange"
+            :ticks="data.ticks"
             :margin="margin"
             :atrributes-chart="true"
           />

--- a/client/src/components/controls/TimelineCharts.vue
+++ b/client/src/components/controls/TimelineCharts.vue
@@ -200,7 +200,7 @@ export default defineComponent({
             v-if="timeline.dismissable"
             icon="mdi-close"
             tooltip-text="Hide Timeline"
-            @click="$emit('dismiss', timeline.name)"
+            @click="$emit('dismiss', {name: timeline.name, height: getTimelineHeight(timeline)})"
           />
         </v-row>
 

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -52,7 +52,7 @@ export interface AttributesFilterType {
   removeTimelineFilter: (name: string) => void;
   attributeTimelineData:
   Readonly<Ref<Record<string, {
-    data: TimelineAttribute[]; begin: number; end: number; yRange?: number[];
+    data: TimelineAttribute[]; begin: number; end: number; yRange?: number[]; ticks?: number;
   }>>>;
   timelineGraphs: Readonly<Ref<Record<string, TimelineGraph>>>;
   timelineEnabled: Readonly<Ref<Record<string, boolean>>>;

--- a/client/src/use/AttributeTypes.ts
+++ b/client/src/use/AttributeTypes.ts
@@ -27,6 +27,7 @@ export interface TimelineGraph {
     enabled: boolean;
     default?: boolean;
     yRange?: number[];
+    ticks?: number;
     settings?: Record<string, TimelineGraphSettings>;
   }
 

--- a/client/src/use/useAttributes.ts
+++ b/client/src/use/useAttributes.ts
@@ -351,7 +351,7 @@ export default function UseAttributes(
   }
 
   const attributeTimelineData = computed(() => {
-    const results: Record<string, { data: TimelineAttribute[]; begin: number; end: number; yRange?: number[]}> = {};
+    const results: Record<string, { data: TimelineAttribute[]; begin: number; end: number; yRange?: number[]; ticks?: number}> = {};
     const val = pendingSaveCount.value; // depends on pending save count so it updates in real time
     if (val !== undefined && selectedTrackId.value !== null) {
       const vals = Object.entries(timelineGraphs.value);
@@ -370,6 +370,7 @@ export default function UseAttributes(
                 begin: timelineData.begin,
                 end: timelineData.end,
                 yRange: graph.yRange,
+                ticks: graph.ticks,
               };
             }
           }

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -240,6 +240,7 @@ class TimeLineGraph(BaseModel):
     filter: AttributeKeyFilter
     default: Optional[bool]
     yRange: Optional[List[float]]
+    ticks: Optional[float]
     settings: Optional[Dict[str, TimeLineGraphSettings]]
 
 


### PR DESCRIPTION
resolves #68 
This was a result of using the return value of spice by mistake instead of remembering it operates on the array in place.

resolves #67 

The timeline will now reflow as charts are dismissed.  This will recalculate the timeline, the video viewing area and the height of the timeline.  As items are added back in it begins to take up more space again.

resolves #65 

Added a setting for double clicking as well as in the timeline Y-Axis settings for specifying the number of Ticks in the Y-Axis.

Also added a new shortcut "shift+T" to the system for toggling the timeline to expand/collapse the area.

Updated the range specification Y-Ranges so it won't add 20% to the top value.  This was done initially so that when it does a calculation of the max value there was some headroom to display it in the chart.  The update means that any user specified range is the exact range now.


https://github.com/BryonLewis/dive-dsa/assets/61746913/50aca551-e137-42bf-ae37-9980615e3cda

