### PR TITLE
Fix Attribute Value Ordering, Fix Configuration Portability

### DIFF
--- a/client/dive-common/components/Attributes/AttributeValueColors.vue
+++ b/client/dive-common/components/Attributes/AttributeValueColors.vue
@@ -232,7 +232,7 @@ export default defineComponent({
         <v-col>
           <v-text-field
             type="number"
-            :value="attributeOrder[key] || -1"
+            :value="attributeOrder[key] !== undefined ? attributeOrder[key] : -1"
             :rules="[v => v >= -1 || 'Value must be greater than -1']"
             label="Order"
             @change="setOrder(key, $event)"

--- a/client/dive-common/components/ControlsContainer.vue
+++ b/client/dive-common/components/ControlsContainer.vue
@@ -81,21 +81,24 @@ export default defineComponent({
       }
     });
     const timelineDisabled = ref(false);
-    if (timelineDefault.value === null && !getUISetting('UIEvents') && !getUISetting('UIDetections')) {
-      const entries = Object.entries(timelineEnabled.value);
-      let found = false;
-      for (let i = 0; i < entries.length; i += 1) {
-        const key = entries[i][0];
-        if (key) {
-          currentView.value = key;
-          found = true;
-          break;
+    const isTimelineEnabled = () => {
+      if (timelineDefault.value === null && !getUISetting('UIEvents') && !getUISetting('UIDetections')) {
+        const entries = Object.entries(timelineEnabled.value);
+        let found = false;
+        for (let i = 0; i < entries.length; i += 1) {
+          const key = entries[i][0];
+          if (key) {
+            currentView.value = key;
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          timelineDisabled.value = true;
         }
       }
-      if (!found) {
-        timelineDisabled.value = true;
-      }
-    }
+    };
+    watch(timelineEnabled, () => isTimelineEnabled());
 
     /**
      * Toggles on and off the individual timeline views

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.9.25",
+  "version": "1.9.26",
   "author": {
     "name": "Kitware, Inc.",
     "email": "viame-web@kitware.com"

--- a/client/src/use/useAttributes.ts
+++ b/client/src/use/useAttributes.ts
@@ -65,12 +65,12 @@ export default function UseAttributes(
 
   function loadTimelines(timelines: Record<string, TimelineGraph>) {
     Object.entries(timelines).forEach(([key, item]) => {
-      timelineGraphs.value[key] = item;
+      VueSet(timelineGraphs.value, key, item);
     });
   }
   function loadSwimlanes(timelines: Record<string, SwimlaneGraph>) {
     Object.entries(timelines).forEach(([key, item]) => {
-      swimlaneGraphs.value[key] = item;
+      VueSet(swimlaneGraphs.value, key, item);
     });
   }
 

--- a/server/dive_server/views_dataset.py
+++ b/server/dive_server/views_dataset.py
@@ -222,11 +222,16 @@ class DatasetResource(Resource):
         setContentDisposition(f'{folder["name"]}.config.json')
         # A dataset configuration consists of MetadataMutable properties.
         expose = MetadataMutable.schema()['properties'].keys()
-        return crud_dataset.get_dataset(folder, self.getCurrentUser()).json(
+        data = crud_dataset.get_dataset(folder, self.getCurrentUser()).json(
             exclude_none=True,
             include=expose,
             indent=2,
         )
+        loaded = json.loads(data)
+        # remove the baseConfiguration Id so it is portable
+        if loaded.get('configuration', {}).get('general', {}).get('baseConfiguration', False):
+            del loaded['configuration']['general']['baseConfiguration']
+        return json.dumps(loaded, indent=2)
 
     @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @rawResponse


### PR DESCRIPTION
resolves #83 
resolves #82 

Ordering was incorrect because of code `value || -1` where value could be 0.  Changed it to a ternary operator `value !=== undefined ? value : -1`

The configuration transfer worked properly in that the data was transferred the problem was in the `reloadAnnotations` it didn't know enough to recalculate the timelines that were being displayed.  I updated the reloading process and some of the loading processes of data to have proper reactivity when loading timelines/swimlanes.

I also updated the export of configuration to remove the baseConfiguration girder Id because that shouldn't be in the portable configuration file.