### PR TITLE
Timeline filtering

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.9.27",
+  "version": "1.9.28",
   "author": {
     "name": "Kitware, Inc.",
     "email": "viame-web@kitware.com"

--- a/client/src/layers/UILayers/AttributeColorKey.vue
+++ b/client/src/layers/UILayers/AttributeColorKey.vue
@@ -15,7 +15,7 @@ import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
   All references to reactive PropType<Ref<data>> need to be dereferenced in the template as well.
  */
 export default defineComponent({
-  name: 'ToolTipWidget',
+  name: 'AttributeColorKey',
   props: {
     attributes: {
       type: Array as PropType<Attribute[]>,
@@ -161,7 +161,7 @@ export default defineComponent({
 
 <template>
   <v-card
-    v-if="numberValueColors.length && stringValueColors.length"
+    v-if="numberValueColors.length || stringValueColors.length"
     dark
     :style="`max-height:${maxHeight}px;
      overflow-y:scroll; z-index:20; min-width:250px; border: 3px white solid;`"

--- a/client/src/use/AttributeTypes.ts
+++ b/client/src/use/AttributeTypes.ts
@@ -5,6 +5,7 @@ export interface SwimlaneGraph {
   filter: AttributeKeyFilter;
   enabled: boolean;
   default?: boolean;
+  displaySettings?: { display: 'static' | 'selected'; trackFilter: string[] };
   settings?: Record<string, SwimlaneGraphSettings>;
 }
 
@@ -28,6 +29,7 @@ export interface TimelineGraph {
     default?: boolean;
     yRange?: number[];
     ticks?: number;
+    displaySettings?: { display: 'static' | 'selected'; trackFilter: string[] };
     settings?: Record<string, TimelineGraphSettings>;
   }
 

--- a/scripts/generateAttention.py
+++ b/scripts/generateAttention.py
@@ -6,7 +6,7 @@ import datetime
 from random import randint
 
 def readinput(file):
-    with open(f'./{file}', 'r') as myfile:
+    with open(f'{file}', 'r') as myfile:
         file_data = myfile.read()
         data = json.loads(file_data)
         return data
@@ -22,13 +22,14 @@ def load_data(input):
     base = randint(0, 100)
     count = 0
     for track in tracks.values():
-        print(track)
         features = track['features']
+        type = track['confidencePairs'][0][0]
+        base_type = type.replace('Track ', '')
         for feature in features:
             newrandom = base + randint(-5, 5)
             newrandom = max(newrandom, 0)
             newrandom = min(100, newrandom)
-            feature['attributes']['ML_Value'] = newrandom
+            feature['attributes'][f'{base_type}_Numerical'] = newrandom
             if count % randint(40, 100) == 0:
                 base = base + randint(-40, 40)
                 base = max(base, 0)

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -173,7 +173,7 @@ class RenderingAttributes(BaseModel):
     displayHeight: RenderingDisplayDimension
 
 
-class ColorKeySettings(BaseModel):
+class DisplayTrackFilterSettings(BaseModel):
     display: Literal['static', 'selected']
     trackFilter: List[str]
 
@@ -191,7 +191,7 @@ class Attribute(BaseModel):
     shortcuts: Optional[List[ShortcutAttributeOptions]]
     render: Optional[RenderingAttributes]
     colorKey: Optional[bool]
-    colorKeySettings: Optional[ColorKeySettings]
+    colorKeySettings: Optional[DisplayTrackFilterSettings]
     valueOrder: Optional[Dict[str, int]]
 
 
@@ -249,6 +249,7 @@ class TimeLineGraph(BaseModel):
     default: Optional[bool]
     yRange: Optional[List[float]]
     ticks: Optional[float]
+    displaySettings: Optional[DisplayTrackFilterSettings]
     settings: Optional[Dict[str, TimeLineGraphSettings]]
 
 
@@ -260,6 +261,7 @@ class SwimlaneGraph(BaseModel):
     enabled: bool
     name: str
     filter: AttributeKeyFilter
+    displaySettings: Optional[DisplayTrackFilterSettings]
     default: Optional[bool]
     settings: Optional[Dict[str, SwimlaneGraphSettings]]
 


### PR DESCRIPTION
resolve #88 

- Key/Legend displaying now has an additional option to only display when certain tracks are selected
- The timeline/swimlane each have an additional section called "Display Settings" that allows the user to set what track types the timeline view is enabled on.

Video below shows how it works in practive.

https://github.com/BryonLewis/dive-dsa/assets/61746913/56c57ebb-ded4-40be-8caf-b8cd5b3c9542

