### PR TITLE
Convert to Dive folder page for only postprocess

### DIFF
--- a/server/dive_server/web_client/views/folderPage.js
+++ b/server/dive_server/web_client/views/folderPage.js
@@ -12,7 +12,7 @@ wrap(HierarchyWidget, 'render', function (render) {
                 </a>`
             );
         }
-        if ( !this.$el.find('.g-dive-convert-item[role="button"]').length && !this.parentModel.attributes.meta.annotate && this.parentModel.attributes.meta.MarkForPostProcess !== false) {
+        if ( !this.$el.find('.g-dive-convert-item[role="button"]').length && !this.parentModel.attributes.meta.annotate && this.parentModel.attributes.meta.MarkForPostProcess === true) {
             this.$el.find('.g-folder-header-buttons .btn-group').before(
                 `<div 
                     class="g-dive-convert-link btn btn-sm btn-primary"


### PR DESCRIPTION
Fixes a bug in which theConvert to Dive button was in every folder.  This updates it so it is only visible in mark for most process folders.