### PR TITLE
skipJobs won't transcode if items are already transcoded

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.11]
+        python-version: [3.11]
     steps:
     - name: Update Package References
       run: sudo apt-get update

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -262,7 +262,7 @@ def postprocess(
         )
 
         for item in videoItems:
-            if item.get("meta", {}).get("codec", None) != None:
+            if item.get("meta", {}).get("codec", None) is not None:
                 continue
             newjob = tasks.convert_video.apply_async(
                 kwargs=dict(

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -262,6 +262,8 @@ def postprocess(
         )
 
         for item in videoItems:
+            if item.get("meta", {}).get("codec", None) != None:
+                continue
             newjob = tasks.convert_video.apply_async(
                 kwargs=dict(
                     folderId=str(item["folderId"]),

--- a/server/dive_server/views_rpc.py
+++ b/server/dive_server/views_rpc.py
@@ -32,7 +32,7 @@ class RpcResource(Resource):
         )
         .param(
             "skipJobs",
-            "Whether to skip processing that might dispatch worker jobs",
+            "Whether to skip processing that might dispatch worker jobs.  If if this is false it will skip transcoding items that have already been processed indicated by having a metadata property 'codec'.",
             paramType="formData",
             dataType="boolean",
             default=False,
@@ -40,7 +40,7 @@ class RpcResource(Resource):
         )
         .param(
             "skipTranscoding",
-            "Whether to skip processing that might dispatch worker jobs",
+            "If skipJobs is False and Skip Transcoding is true it will still run a job and attempt to see if the video file meets requirements (h264 encoding with .mp4 container) and won't transcode unless it is necessary",
             paramType="formData",
             dataType="boolean",
             default=False,
@@ -48,7 +48,7 @@ class RpcResource(Resource):
         )
         .param(
             "additive",
-            "Whether to add new annotations to existing ones",
+            "Whether to add new annotations to existing ones.  Annotations will be added with Ids starting at the last existing Id+1",
             paramType="formData",
             dataType="boolean",
             default=False,
@@ -56,7 +56,7 @@ class RpcResource(Resource):
         )
         .param(
             "additivePrepend",
-            "When using additive the prepend to types: 'prepend_type'",
+            "When using additive the prepend to types: I.E. 'prepend_type' so the string will be added to all types that are imported",
             paramType="formData",
             dataType="string",
             default='',
@@ -137,7 +137,7 @@ class RpcResource(Resource):
         )
         .param(
             "skipJobs",
-            "Whether to skip processing that might dispatch worker jobs",
+            "Whether to skip processing that might dispatch worker jobs.  If if this is false it will skip transcoding items that have already been processed indicated by having a metadata property 'codec'.",
             paramType="formData",
             dataType="boolean",
             default=False,
@@ -145,7 +145,7 @@ class RpcResource(Resource):
         )
         .param(
             "skipTranscoding",
-            "Whether to skip processing that might dispatch worker jobs",
+            "If skipJobs is False and Skip Transcoding is true it will still run a job and attempt to see if the video file meets requirements (h264 encoding with .mp4 container) and won't transcode unless it is necessary",
             paramType="formData",
             dataType="boolean",
             default=False,

--- a/server/dive_server/views_rpc.py
+++ b/server/dive_server/views_rpc.py
@@ -32,7 +32,9 @@ class RpcResource(Resource):
         )
         .param(
             "skipJobs",
-            "Whether to skip processing that might dispatch worker jobs.  If if this is false it will skip transcoding items that have already been processed indicated by having a metadata property 'codec'.",
+            "Whether to skip processing that might dispatch worker jobs.  \
+            If if this is false it will skip transcoding items that have \
+            already been processed indicated by having a metadata property 'codec'.",
             paramType="formData",
             dataType="boolean",
             default=False,
@@ -40,7 +42,10 @@ class RpcResource(Resource):
         )
         .param(
             "skipTranscoding",
-            "If skipJobs is False and Skip Transcoding is true it will still run a job and attempt to see if the video file meets requirements (h264 encoding with .mp4 container) and won't transcode unless it is necessary",
+            "If skipJobs is False and Skip Transcoding is true it will still \
+            run a job and attempt to see if the video file meets \
+            requirements (h264 encoding with .mp4 container) and \
+            won't transcode unless it is necessary",
             paramType="formData",
             dataType="boolean",
             default=False,
@@ -48,7 +53,8 @@ class RpcResource(Resource):
         )
         .param(
             "additive",
-            "Whether to add new annotations to existing ones.  Annotations will be added with Ids starting at the last existing Id+1",
+            "Whether to add new annotations to existing ones.  Annotations \
+            will be added with Ids starting at the last existing Id+1",
             paramType="formData",
             dataType="boolean",
             default=False,
@@ -56,7 +62,8 @@ class RpcResource(Resource):
         )
         .param(
             "additivePrepend",
-            "When using additive the prepend to types: I.E. 'prepend_type' so the string will be added to all types that are imported",
+            "When using additive the prepend to types: I.E. 'prepend_type' \
+            so the string will be added to all types that are imported",
             paramType="formData",
             dataType="string",
             default='',
@@ -137,7 +144,9 @@ class RpcResource(Resource):
         )
         .param(
             "skipJobs",
-            "Whether to skip processing that might dispatch worker jobs.  If if this is false it will skip transcoding items that have already been processed indicated by having a metadata property 'codec'.",
+            "Whether to skip processing that might dispatch worker jobs.  \
+            If if this is false it will skip transcoding items that have \
+            already been processed indicated by having a metadata property 'codec'.",
             paramType="formData",
             dataType="boolean",
             default=False,
@@ -145,7 +154,10 @@ class RpcResource(Resource):
         )
         .param(
             "skipTranscoding",
-            "If skipJobs is False and Skip Transcoding is true it will still run a job and attempt to see if the video file meets requirements (h264 encoding with .mp4 container) and won't transcode unless it is necessary",
+            "If skipJobs is False and Skip Transcoding is true it will still \
+            run a job and attempt to see if the video file meets \
+            requirements (h264 encoding with .mp4 container) and \
+            won't transcode unless it is necessary",
             paramType="formData",
             dataType="boolean",
             default=False,


### PR DESCRIPTION
- Made it so if there are video files that already contain the metadata 'codec' indicating that it has been transcoded it will prevent it from running a transcode job again.