### PR TITLE
fix coco import

### DIFF
--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -12,9 +12,13 @@ from . import viame
 
 
 def is_coco_json(coco: Dict[str, Any]):
-    # Required COCO fields according to https://cocodataset.org/#format-data
-    keys = ['info', 'images', 'annotations', 'categories']
-    return all(key in coco for key in keys)
+    # Fields required by the DIVE importer. `info` is part of the COCO spec but is
+    # often omitted by exporters (e.g. pycocotools); tests use JSON without it too.
+    keys = ['images', 'annotations', 'categories']
+    if not all(key in coco for key in keys):
+        return False
+    # Avoid treating DIVE track JSON as COCO when both schemas share top-level keys.
+    return 'tracks' not in coco
 
 
 def annotation_info(annotation: dict, meta: CocoMetadata) -> Tuple[int, str, int, List[int]]:

--- a/server/tests/test_deserialize_kwcoco_json.py
+++ b/server/tests/test_deserialize_kwcoco_json.py
@@ -703,3 +703,9 @@ def test_read_kwcoco_json(
         expected_tracks, sort_keys=True
     )
     assert json.dumps(attributes, sort_keys=True) == json.dumps(expected_attributes, sort_keys=True)
+
+
+def test_is_coco_json_without_info():
+    assert kwcoco.is_coco_json(test_tuple[0][0])
+    assert not kwcoco.is_coco_json({'tracks': {}, 'groups': {}, 'version': 2})
+    assert not kwcoco.is_coco_json({'images': [], 'annotations': []})


### PR DESCRIPTION
Removes 'info' key from being required in coco importing, updates test as well.