### PR TITLE
Coco score format handler

### DIFF
--- a/scripts/cocoGenerateTestImages.py
+++ b/scripts/cocoGenerateTestImages.py
@@ -1,0 +1,160 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "click",
+#     "pillow",
+# ]
+# ///
+"""Generate placeholder images for each entry in a COCO/KWCOCO images list."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+from PIL import Image, ImageDraw, ImageFont
+
+
+def require_image_size(image: dict) -> tuple[int, int]:
+    missing = [key for key in ("width", "height") if key not in image]
+    if missing:
+        image_id = image.get("id", "?")
+        file_name = image.get("file_name", "?")
+        raise click.ClickException(
+            f"Image id={image_id} file_name={file_name!r} "
+            f"is missing: {', '.join(missing)}"
+        )
+
+    width = int(image["width"])
+    height = int(image["height"])
+    if width <= 0 or height <= 0:
+        raise click.ClickException(
+            f"Image id={image.get('id', '?')} "
+            f"has invalid size: {width}x{height}"
+        )
+    return width, height
+
+
+def background_color(image_id: object) -> tuple[int, int, int]:
+    seed = int(image_id) if isinstance(image_id, int) else hash(str(image_id))
+    return (
+        (seed * 37) % 200 + 40,
+        (seed * 59) % 200 + 40,
+        (seed * 83) % 200 + 40,
+    )
+
+
+def pil_format(path: Path) -> str | None:
+    ext = path.suffix.lower().lstrip(".")
+    return {
+        "jpg": "JPEG",
+        "jpeg": "JPEG",
+        "png": "PNG",
+        "webp": "WEBP",
+        "bmp": "BMP",
+        "tif": "TIFF",
+        "tiff": "TIFF",
+    }.get(ext)
+
+
+def write_test_image(image: dict, output_path: Path) -> None:
+    image_id = image.get("id", "?")
+    file_name = image["file_name"]
+    width, height = require_image_size(image)
+
+    img = Image.new("RGB", (width, height), background_color(image_id))
+    draw = ImageDraw.Draw(img)
+
+    step = max(32, min(width, height) // 12)
+    for y in range(0, height, step):
+        for x in range(0, width, step):
+            if ((x // step) + (y // step)) % 2:
+                draw.rectangle([x, y, x + step, y + step], fill=(220, 220, 220))
+
+    lines = [f"id: {image_id}", Path(file_name).name, f"{width} x {height}"]
+    if "frame_index" in image:
+        lines.append(f"frame: {image['frame_index']}")
+
+    try:
+        font = ImageFont.load_default(size=min(24, max(12, height // 24)))
+    except TypeError:
+        font = ImageFont.load_default()
+
+    draw.multiline_text(
+        (8, 8), "\n".join(lines), fill=(0, 0, 0), font=font, spacing=4
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    save_format = pil_format(output_path)
+    if save_format == "JPEG":
+        img.save(output_path, format=save_format, quality=90)
+    else:
+        img.save(output_path, format=save_format)
+
+
+@click.command()
+@click.argument(
+    "coco_json",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Output directory "
+        "(default: <coco-stem>_images next to the JSON file)."
+    ),
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    help="Replace images that already exist.",
+)
+def main(coco_json: Path, output_dir: Path | None, overwrite: bool) -> None:
+    """Create test images named and sized per COCO/KWCOCO images list."""
+    with coco_json.open(encoding="utf-8") as fp:
+        data = json.load(fp)
+
+    images = data.get("images")
+    if not images:
+        raise click.ClickException("COCO JSON has no 'images' list.")
+
+    if output_dir is None:
+        output_dir = coco_json.with_name(f"{coco_json.stem}_images")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    created = 0
+    skipped = 0
+
+    for image in images:
+        if "file_name" not in image:
+            raise click.ClickException(
+                f"Image entry missing file_name: {image!r}"
+            )
+
+        relative = Path(image["file_name"])
+        if relative.is_absolute():
+            raise click.ClickException(
+                f"file_name must be relative: {image['file_name']!r}"
+            )
+
+        out_path = output_dir / relative
+        if out_path.exists() and not overwrite:
+            skipped += 1
+            continue
+
+        write_test_image(image, out_path)
+        created += 1
+
+    click.echo(f"Wrote {created} image(s) to {output_dir}")
+    if skipped:
+        click.echo(
+            f"Skipped {skipped} existing file(s) "
+            "(use --overwrite to replace)."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -21,6 +21,17 @@ def is_coco_json(coco: Dict[str, Any]):
     return 'tracks' not in coco
 
 
+def _normalize_score(score: Any) -> float:
+    """Some exporters use score: [0.9] instead of scalar 0.9."""
+    if isinstance(score, (list, tuple)):
+        if not score:
+            return 1.0
+        score = score[0]
+    if score is None:
+        return 1.0
+    return float(score)
+
+
 def annotation_info(annotation: dict, meta: CocoMetadata) -> Tuple[int, str, int, List[int]]:
     # these fields will always exist
     annotation_id = annotation['id']
@@ -50,7 +61,7 @@ def _parse_annotation(annotation: dict, meta: CocoMetadata) -> Tuple[dict, dict,
     track_attributes: Dict[str, Any] = {}
 
     category_id = annotation['category_id']
-    score = annotation.get('score', 1.0)  # may not exist, default to 1.0
+    score = _normalize_score(annotation.get('score', 1.0))
     class_name = meta.categories[category_id]['name']
     confidence_pair = (class_name, score)
 

--- a/server/tests/test_deserialize_kwcoco_json.py
+++ b/server/tests/test_deserialize_kwcoco_json.py
@@ -709,3 +709,22 @@ def test_is_coco_json_without_info():
     assert kwcoco.is_coco_json(test_tuple[0][0])
     assert not kwcoco.is_coco_json({'tracks': {}, 'groups': {}, 'version': 2})
     assert not kwcoco.is_coco_json({'images': [], 'annotations': []})
+
+
+def test_litdet_array_score_import():
+    """Some exporters use score: [0.9] instead of scalar 0.9."""
+    coco = {
+        'categories': [{'id': 1, 'name': 'test'}],
+        'images': [{'id': 1, 'file_name': '1.png', 'width': 100, 'height': 100}],
+        'annotations': [
+            {
+                'id': 1,
+                'image_id': 1,
+                'category_id': 1,
+                'bbox': [10.0, 10.0, 20.0, 30.0],
+                'score': [0.747],
+            }
+        ],
+    }
+    converted, _ = kwcoco.load_coco_as_tracks_and_attributes(coco)
+    assert converted['tracks']['1']['confidencePairs'] == [('test', 0.747)]


### PR DESCRIPTION
resolves #438 

The score was being imported as `score: [0.9]` instead of `score: 0.9` so I wrote a normalizer to handle this.
I don't think score is really specified in detail within the COCO spec, I assumed it was a raw float value but it seems it could also be an array value.  I've added code to handle this as well as a test.

Additionally added a uv script for easily taking a COCO JSON and generating random images for testing.