### PR TITLE
Dive metadata recursive

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,4 @@
+version: 2
+secret:
+  ignored_paths:
+    - scripts/assetStoreImport/minIOConfig.py

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.11.31",
+  "version": "1.11.32",
   "author": {
     "name": "Kitware, Inc.",
     "email": "Bryon.Lewis@kitware.com"

--- a/client/platform/web-girder/api/divemetadata.service.ts
+++ b/client/platform/web-girder/api/divemetadata.service.ts
@@ -218,6 +218,15 @@ export interface createDiveMetadataRecursiveResponse {
   errors: string[];
 }
 
+export interface IndexDiveMetadataFolderResponse {
+  results: string;
+  metadataFolderId: string;
+  rootFolderId: string;
+  added: number;
+  existing: number;
+  datasetCount: number;
+}
+
 function createDiveMetadataFolder(
   parentFolder: string,
   name: string,
@@ -267,6 +276,27 @@ function createDiveMetadataRecursive(
       ffprobeMetadata: toJsonParam(ffprobeMetadata),
     },
   });
+}
+
+function indexDiveMetadataFromFolder(
+  metadataFolderId: string,
+  rootFolderId: string,
+  replaceMetadata = false,
+  ffprobeMetadata = {
+    import: true, keys: ['width', 'height', 'display_aspect_ratio', 'nb_frames', 'duration'],
+  },
+) {
+  return girderRest.post<IndexDiveMetadataFolderResponse>(
+    `dive_metadata/${metadataFolderId}/index_folder`,
+    null,
+    {
+      params: {
+        rootFolderId,
+        replaceMetadata,
+        ffprobeMetadata: toJsonParam(ffprobeMetadata),
+      },
+    },
+  );
 }
 
 function modifyDiveMetadataPermission(rootMetadataFolder: string, key: string, unlocked: boolean) {
@@ -476,6 +506,7 @@ export {
   createDiveMetadataClone,
   createDiveMetadataFolder,
   createDiveMetadataRecursive,
+  indexDiveMetadataFromFolder,
   modifyDiveMetadataPermission,
   addDiveMetadataKey,
   updateDiveMetadataKeyDescription,

--- a/client/platform/web-girder/api/divemetadata.service.ts
+++ b/client/platform/web-girder/api/divemetadata.service.ts
@@ -197,7 +197,25 @@ export interface createDiveMetadataResponse {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   'metadataKeys': any[];
   'folderId': string;
+  existing?: number;
+}
 
+export interface CreateDiveMetadataRecursiveEntry {
+  rootFolderId: string;
+  metadataFolderId?: string;
+  added?: number;
+  existing?: number;
+  reusedExisting?: boolean;
+  reason?: string;
+}
+
+export interface createDiveMetadataRecursiveResponse {
+  scope: 'single' | 'subfolders';
+  resourceType: 'folder' | 'collection';
+  resourceId: string;
+  created: CreateDiveMetadataRecursiveEntry[];
+  existing: CreateDiveMetadataRecursiveEntry[];
+  errors: string[];
 }
 
 function createDiveMetadataFolder(
@@ -217,6 +235,34 @@ function createDiveMetadataFolder(
       name,
       rootFolderId,
       categoricalLimit,
+      displayConfig: toJsonParam(displayConfig),
+      ffprobeMetadata: toJsonParam(ffprobeMetadata),
+    },
+  });
+}
+
+function createDiveMetadataRecursive(
+  resourceId: string,
+  resourceType: 'folder' | 'collection',
+  scope: 'single' | 'subfolders' = 'subfolders',
+  name = 'DIVE Metadata',
+  categoricalLimit = 50,
+  parentFolderId?: string,
+  displayConfig = {
+    display: ['DIVE_DatasetId', 'DIVE_Name'],
+  },
+  ffprobeMetadata = {
+    import: true, keys: ['width', 'height', 'display_aspect_ratio', 'nb_frames', 'duration'],
+  },
+) {
+  return girderRest.post<createDiveMetadataRecursiveResponse>('dive_metadata/create_metadata_recursive', null, {
+    params: {
+      resourceId,
+      resourceType,
+      scope,
+      name,
+      categoricalLimit,
+      parentFolderId,
       displayConfig: toJsonParam(displayConfig),
       ffprobeMetadata: toJsonParam(ffprobeMetadata),
     },
@@ -429,6 +475,7 @@ export {
   getDiveDatasetMetadataRow,
   createDiveMetadataClone,
   createDiveMetadataFolder,
+  createDiveMetadataRecursive,
   modifyDiveMetadataPermission,
   addDiveMetadataKey,
   updateDiveMetadataKeyDescription,

--- a/client/platform/web-girder/views/CreateDIVEMetadata.vue
+++ b/client/platform/web-girder/views/CreateDIVEMetadata.vue
@@ -8,7 +8,11 @@ import { RootlessLocationType } from 'platform/web-girder/store/types';
 import { useGirderRest } from 'platform/web-girder/plugins/girder';
 import { getFolder } from 'platform/web-girder/api';
 import { useRouter } from 'vue-router/composables';
-import { createDiveMetadataFolder } from 'platform/web-girder/api/divemetadata.service';
+import {
+  createDiveMetadataFolder,
+  createDiveMetadataRecursive,
+} from 'platform/web-girder/api/divemetadata.service';
+import eventBus from '../eventBus';
 import type { GirderModel } from 'vue-girder-slicer-cli-ui/dist/girderTypes';
 
 export default defineComponent({
@@ -18,6 +22,14 @@ export default defineComponent({
     datasetId: {
       type: String as PropType<string | null>,
       default: null,
+    },
+    resourceType: {
+      type: String as PropType<'folder' | 'collection' | null>,
+      default: null,
+    },
+    resourceName: {
+      type: String,
+      default: '',
     },
     revision: {
       type: Number,
@@ -36,23 +48,49 @@ export default defineComponent({
   setup(props) {
     const router = useRouter();
     const girderRest = useGirderRest();
-    const source = ref(null as GirderModel | null);
+    const source = ref(null as GirderModel | { _id: string; _modelType: string; name: string } | null);
     const open = ref(false);
     const categoricalLimit = ref(50);
+    const perSubfolder = ref(false);
+    const scope = ref<'single' | 'subfolders'>('single');
     const location: Ref<RootlessLocationType> = ref({
       _modelType: ('user' as GirderModelType),
       _id: girderRest.user._id,
     });
-    const newName = ref('');
+    const newName = ref('DIVE Metadata');
 
+    const isCollection = computed(() => props.resourceType === 'collection');
+    const useRecursiveApi = computed(
+      () => isCollection.value || perSubfolder.value,
+    );
     const locationIsFolder = computed(() => (location.value._modelType === 'folder'));
+    const effectiveScope = computed(() => {
+      if (isCollection.value) {
+        return scope.value;
+      }
+      return perSubfolder.value ? 'subfolders' : 'single';
+    });
 
     async function click() {
-      if (props.datasetId) {
+      if (!props.datasetId) {
+        return;
+      }
+      if (props.resourceType === 'collection') {
+        source.value = {
+          _id: props.datasetId,
+          _modelType: 'collection',
+          name: props.resourceName || 'Collection',
+        };
+        scope.value = 'subfolders';
+        perSubfolder.value = true;
+        newName.value = 'DIVE Metadata';
+      } else {
         source.value = (await getFolder(props.datasetId)).data;
         newName.value = `DiveMetadata of ${source.value.name}`;
-        open.value = true;
+        scope.value = 'single';
+        perSubfolder.value = false;
       }
+      open.value = true;
     }
 
     function setLocation(newLoc: RootlessLocationType) {
@@ -64,7 +102,38 @@ export default defineComponent({
     const { request: _createRequest, error: createError, loading: createLoading } = useRequest();
     const doCreate = () => _createRequest(async () => {
       if (!props.datasetId) {
-        throw new Error('no source dataset');
+        throw new Error('no source resource');
+      }
+      if (useRecursiveApi.value) {
+        const result = await createDiveMetadataRecursive(
+          props.datasetId,
+          isCollection.value ? 'collection' : 'folder',
+          effectiveScope.value,
+          newName.value,
+          categoricalLimit.value,
+        );
+        const { created, existing, errors } = result.data;
+        const hasWork = created.length > 0
+          || existing.some((entry) => entry.metadataFolderId);
+        if (!hasWork) {
+          throw new Error(
+            errors.join('; ')
+            || 'No metadata folders were created or updated',
+          );
+        }
+        if (effectiveScope.value === 'subfolders') {
+          open.value = false;
+          eventBus.$emit('refresh-data-browser');
+          return;
+        }
+        const first = created.find((entry) => entry.metadataFolderId)
+          || existing.find((entry) => entry.metadataFolderId);
+        open.value = false;
+        router.push({ name: 'metadata', params: { id: first!.metadataFolderId! } });
+        return;
+      }
+      if (!locationIsFolder.value) {
+        throw new Error('Choose a destination folder');
       }
       const newDataset = await createDiveMetadataFolder(
         location.value._id,
@@ -73,6 +142,7 @@ export default defineComponent({
         categoricalLimit.value,
       );
       router.push({ name: 'metadata', params: { id: newDataset.data.folderId } });
+      open.value = false;
     });
 
     return {
@@ -84,6 +154,11 @@ export default defineComponent({
       open,
       source,
       categoricalLimit,
+      perSubfolder,
+      scope,
+      isCollection,
+      useRecursiveApi,
+      effectiveScope,
       /* methods */
       click,
       doCreate,
@@ -124,23 +199,29 @@ export default defineComponent({
             <v-spacer />
           </v-btn>
         </template>
-        <span>Create a DIVEMetadata Item based on subfolders</span>
+        <span>Create DIVE metadata for this folder or collection (skips existing metadata)</span>
       </v-tooltip>
     </template>
 
     <v-card v-if="source">
       <v-divider />
       <v-card-title>
-        Create a DIVEMetadata Item from the current folder
+        Create DIVE metadata from {{ source.name }}
       </v-card-title>
       <v-card-text>
         <v-card-text>
-          This will generate a DIVEMetadata Item for the current folder.  It will recursively find all DIVE
-          Datasets in the children folder and extract the filename, id, and ffmpeg information for indexing purposes.
-          After this is complete you can then use the <v-chip>edit filters</v-chip> button to add new fields and change what fields are bvisible by default.
+          <p v-if="isCollection">
+            For a <strong>collection</strong>, you can create one metadata folder for the whole
+            collection or one per top-level folder (as a sibling folder next to each one). Existing
+            metadata folders are reused and only missing datasets are indexed.
+          </p>
+          <p v-else>
+            This indexes DIVE datasets under the current folder. Existing metadata rows are not
+            replaced. Choose a destination folder, or enable per-subfolder creation below.
+          </p>
           <v-text-field
             v-model="newName"
-            label="New MetadataFolder name"
+            label="Metadata folder name"
             class="mt-4"
             outlined
             dense
@@ -152,12 +233,35 @@ export default defineComponent({
             label="Categorical Limit"
             hint="number of unique values before converting to a searchable field"
           />
+          <v-radio-group
+            v-if="isCollection"
+            v-model="scope"
+            label="Collection scope"
+            class="mt-2"
+          >
+            <v-radio
+              label="One metadata folder for the entire collection"
+              value="single"
+            />
+            <v-radio
+              label="One metadata folder per top-level folder"
+              value="subfolders"
+            />
+          </v-radio-group>
+          <v-checkbox
+            v-else
+            v-model="perSubfolder"
+            label="Create a sibling metadata folder for each immediate subfolder"
+            class="mt-2"
+          />
 
           <v-card
+            v-if="!useRecursiveApi"
             outlined
             flat
+            class="mt-2"
           >
-            <p>Choose a location where the new metadataFolder should be placed</p>
+            <p>Choose where the new metadata folder should be placed</p>
             <GirderFileManager
               new-folder-enabled
               no-access-control-w
@@ -184,17 +288,23 @@ export default defineComponent({
             color="primary"
             class="mt-4"
             :loading="createLoading"
-            :disabled="!locationIsFolder || createLoading"
+            :disabled="(!useRecursiveApi && !locationIsFolder) || createLoading"
             @click="doCreate"
           >
-            <span v-if="!locationIsFolder">
+            <span v-if="!useRecursiveApi && !locationIsFolder">
               Choose a destination folder...
             </span>
+            <span v-else-if="useRecursiveApi && effectiveScope === 'subfolders'">
+              Create metadata for subfolders of {{ source.name }}
+            </span>
+            <span v-else-if="useRecursiveApi">
+              Create metadata for {{ source.name }}
+            </span>
             <span v-else-if="'name' in location">
-              Create DIVEMetadata Item into {{ location.name }}
+              Create metadata folder in {{ location.name }}
             </span>
             <span v-else>
-              Something went wrong
+              Create metadata
             </span>
           </v-btn>
         </v-card-text>

--- a/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataFilter.vue
+++ b/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataFilter.vue
@@ -14,11 +14,17 @@ import DIVEMetadataCloneVue from './DIVEMetadataClone.vue';
 import DIVEMetadataSlicerVue from './DIVEMetadataSlicer.vue';
 import DIVEMetadataExportVue from './DIVEMetadataExport.vue';
 import DIVEMetadataImportVue from './DIVEMetadataImport.vue';
+import DIVEMetadataIndexFolderVue from './DIVEMetadataIndexFolder.vue';
 
 export default defineComponent({
   name: 'DIVEMetadataFilter',
   components: {
-    DIVEMetadataFilterItemVue, DIVEMetadataCloneVue, DIVEMetadataSlicerVue, DIVEMetadataExportVue, DIVEMetadataImportVue,
+    DIVEMetadataFilterItemVue,
+    DIVEMetadataCloneVue,
+    DIVEMetadataSlicerVue,
+    DIVEMetadataExportVue,
+    DIVEMetadataImportVue,
+    DIVEMetadataIndexFolderVue,
   },
   props: {
     currentPage: {
@@ -362,6 +368,12 @@ export default defineComponent({
 
         <v-spacer />
         <DIVEMetadataSlicerVue v-if="showSlicerCLI" :filters="currentFilter" :metadata-root="id" class="mr-2" @job-complete="jobCompleted()" />
+        <DIVEMetadataIndexFolderVue
+          v-if="ownerAdmin"
+          :metadata-root="id"
+          class="mr-2"
+          @updated="metadataImported()"
+        />
         <DIVEMetadataImportVue v-if="ownerAdmin" :metadata-root="id" class="mr-2" @updated="metadataImported()" />
         <DIVEMetadataExportVue :metadata-root="id" :filters="currentFilter" class="pr-4" />
         <v-chip><span class="pr-1">Filtered:</span>{{ filtered }} / {{ count }}</v-chip>

--- a/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataIndexFolder.vue
+++ b/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataIndexFolder.vue
@@ -1,0 +1,179 @@
+<script lang="ts">
+import {
+  computed, defineComponent, Ref, ref,
+} from 'vue';
+import { GirderFileManager, GirderModelType } from '@girder/components/src';
+import useRequest from 'dive-common/use/useRequest';
+import { RootlessLocationType } from 'platform/web-girder/store/types';
+import { useGirderRest } from 'platform/web-girder/plugins/girder';
+import { indexDiveMetadataFromFolder } from 'platform/web-girder/api/divemetadata.service';
+import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
+
+export default defineComponent({
+  name: 'DIVEMetadataIndexFolder',
+  components: { GirderFileManager },
+
+  props: {
+    metadataRoot: {
+      type: String,
+      required: true,
+    },
+    buttonOptions: {
+      type: Object,
+      default: () => ({}),
+    },
+    menuOptions: {
+      type: Object,
+      default: () => ({}),
+    },
+    readOnlyMode: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  emits: ['updated'],
+
+  setup(props, { emit }) {
+    const girderRest = useGirderRest();
+    const { prompt } = usePrompt();
+    const open = ref(false);
+    const replaceMetadata = ref(false);
+    const location: Ref<RootlessLocationType> = ref({
+      _modelType: ('user' as GirderModelType),
+      _id: girderRest.user._id,
+    });
+    const locationIsFolder = computed(() => location.value._modelType === 'folder');
+
+    function setLocation(newLoc: RootlessLocationType) {
+      if (!('meta' in newLoc && newLoc.meta.annotate)) {
+        location.value = newLoc;
+      }
+    }
+
+    const { request: runIndex, error: indexError, loading: indexLoading } = useRequest();
+    const doIndex = () => runIndex(async () => {
+      if (!locationIsFolder.value) {
+        throw new Error('Choose a folder to index');
+      }
+      const { data } = await indexDiveMetadataFromFolder(
+        props.metadataRoot,
+        location.value._id,
+        replaceMetadata.value,
+      );
+      open.value = false;
+      emit('updated');
+      await prompt({
+        title: 'Folder indexed',
+        text: [data.results],
+        positiveButton: 'OK',
+      });
+    });
+
+    return {
+      open,
+      replaceMetadata,
+      location,
+      locationIsFolder,
+      indexLoading,
+      indexError,
+      setLocation,
+      doIndex,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-dialog
+    v-model="open"
+    :max-width="720"
+    :overlay-opacity="0.95"
+  >
+    <template #activator="{ on: dialogOn, attrs }">
+      <v-tooltip bottom>
+        <template #activator="{ on: tooltipOn }">
+          <v-btn
+            v-bind="{ ...attrs, ...buttonOptions }"
+            :disabled="readOnlyMode"
+            v-on="{ ...tooltipOn, ...dialogOn }"
+          >
+            <v-icon>mdi-folder-sync</v-icon>
+            <span
+              v-show="buttonOptions.block"
+              class="pl-1"
+            >
+              Add folder
+            </span>
+          </v-btn>
+        </template>
+        <span>Add or refresh datasets from another folder</span>
+      </v-tooltip>
+    </template>
+
+    <v-card>
+      <v-card-title>
+        Index datasets from folder
+      </v-card-title>
+      <v-card-text>
+        <v-alert
+          v-if="indexError"
+          type="error"
+          dismissible
+        >
+          {{ indexError }}
+        </v-alert>
+        <p>
+          Scan a Girder folder (and its subfolders) for DIVE datasets and add them to this
+          metadata collection. Datasets already in the collection are skipped unless you enable
+          replace below.
+        </p>
+        <v-checkbox
+          v-model="replaceMetadata"
+          label="Replace default metadata for datasets found in this folder"
+          :disabled="indexLoading || readOnlyMode"
+          hide-details
+          class="mb-2"
+        />
+        <GirderFileManager
+          new-folder-enabled
+          no-access-control-w
+          :location="location"
+          @update:location="setLocation"
+        >
+          <template #row="{ item }">
+            <span>{{ item.name }}</span>
+            <v-chip
+              v-if="(item.meta && item.meta.annotate)"
+              color="white"
+              x-small
+              outlined
+              class="mx-3"
+            >
+              dataset
+            </v-chip>
+          </template>
+        </GirderFileManager>
+        <v-btn
+          depressed
+          block
+          color="primary"
+          class="mt-4"
+          :loading="indexLoading"
+          :disabled="!locationIsFolder || indexLoading || readOnlyMode"
+          @click="doIndex"
+        >
+          <span v-if="!locationIsFolder">
+            Choose a folder...
+          </span>
+          <span v-else-if="'name' in location">
+            Index datasets under {{ location.name }}
+          </span>
+          <span v-else>
+            Index folder
+          </span>
+        </v-btn>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -95,6 +95,19 @@ export default defineComponent({
       });
       return results;
     },
+    metadataLocationId() {
+      return this.location?._id ?? null;
+    },
+    metadataResourceType() {
+      const modelType = this.location?._modelType;
+      if (modelType === 'collection' || modelType === 'folder') {
+        return modelType;
+      }
+      return null;
+    },
+    metadataResourceName() {
+      return this.location?.name ?? '';
+    },
   },
   methods: {
     async deleteSelection() {
@@ -159,7 +172,9 @@ export default defineComponent({
                 />
                 <CreateDIVEMetadata
                   v-bind="{ buttonOptions, menuOptions }"
-                  :dataset-id="location?._id || null"
+                  :dataset-id="metadataLocationId"
+                  :resource-type="metadataResourceType"
+                  :resource-name="metadataResourceName"
                 />
 
                 <v-btn

--- a/docs/DIVE-Metadata.md
+++ b/docs/DIVE-Metadata.md
@@ -84,6 +84,20 @@ Creates metadata for a Girder **folder** or **collection** without replacing exi
 
 Existing metadata folders are reused; only missing datasets are indexed. Folders that already have a DIVE metadata child are updated in place when new datasets appear.
 
+### Adding datasets from another folder (reindex)
+
+**POST** `/dive_metadata/{metadataFolderId}/index_folder`
+
+Indexes DIVE datasets from a Girder folder into an **existing** DIVE metadata folder (the metadata search UI exposes this as **Add folder**).
+
+| Parameter | Description |
+|-----------|-------------|
+| `rootFolderId` | Folder to scan recursively for DIVE datasets |
+| `replaceMetadata` | When `true`, overwrite default metadata rows (`DIVE_*`, ffprobe fields) for datasets found under `rootFolderId`; custom keys from CSV/JSON import are unchanged unless you re-import those files |
+| `ffprobeMetadata` | Same object as `create_metadata_folder` (optional) |
+
+Only datasets not yet in the metadata root are added by default. Use this after importing new media into a sibling or child folder, or to attach a second dataset tree to one metadata collection.
+
 ### Ingesting DIVE Metadata
 
 **POST** `/dive_metadata/process_metadata/{id}`

--- a/docs/DIVE-Metadata.md
+++ b/docs/DIVE-Metadata.md
@@ -63,6 +63,27 @@ This object controls key visibility, ordering, grouping, and some UI behavior.
 
 A new collection of URL endpoints under `dive_metadata` allows for importing and querying DIVE Metadata.
 
+### Creating metadata from folders or collections
+
+**POST** `/dive_metadata/create_metadata_folder/{parentFolderId}`
+
+Creates a DIVE metadata folder under `parentFolderId` and indexes datasets under `rootFolderId`. If a metadata folder already exists under the parent, it is reused. Existing per-dataset metadata rows are not overwritten.
+
+**POST** `/dive_metadata/create_metadata_recursive`
+
+Creates metadata for a Girder **folder** or **collection** without replacing existing metadata.
+
+| Parameter | Description |
+|-----------|-------------|
+| `resourceId` | Folder or collection ID |
+| `resourceType` | `folder` or `collection` |
+| `scope` | `single` (one metadata folder for the resource) or `subfolders` (one metadata folder per immediate child folder, created as a **sibling** next to that folder) |
+| `name` | Metadata folder name (`<child> - <name>` sibling folder name when `scope=subfolders`) |
+| `parentFolderId` | Optional parent for `scope=single` on a folder |
+| `displayConfig` / `ffprobeMetadata` / `categoricalLimit` | Same as `create_metadata_folder` |
+
+Existing metadata folders are reused; only missing datasets are indexed. Folders that already have a DIVE metadata child are updated in place when new datasets appear.
+
 ### Ingesting DIVE Metadata
 
 **POST** `/dive_metadata/process_metadata/{id}`

--- a/scripts/assetStoreImport/.gitignore
+++ b/scripts/assetStoreImport/.gitignore
@@ -1,0 +1,5 @@
+*.json
+*.csv
+*.jpg
+*.jpeg
+*.mp4

--- a/scripts/assetStoreImport/generateQuickVideos.py
+++ b/scripts/assetStoreImport/generateQuickVideos.py
@@ -1,0 +1,235 @@
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "click",
+#     "faker",
+# ]
+# ///
+import subprocess
+import shutil
+import random
+import json
+import math
+from pathlib import Path
+import click
+from faker import Faker
+
+fake = Faker()
+
+FRAME_WIDTH = 1280
+FRAME_HEIGHT = 720
+FPS = 30
+
+
+def create_base_video(file_path: Path, duration: int):
+    """Create a single base test video using ffmpeg (MP4 container, H.264 codec)."""
+    cmd = [
+        "ffmpeg", "-y",
+        "-f", "lavfi", "-i", f"testsrc=size={FRAME_WIDTH}x{FRAME_HEIGHT}:rate={FPS}",
+        "-t", str(duration),
+        "-c:v", "libx264",
+        "-pix_fmt", "yuv420p",
+        str(file_path)
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def copy_video_to_new_location(base_video: Path, target_path: Path):
+    """Copy the base video to a new file path."""
+    shutil.copy2(base_video, target_path)
+
+
+# ---- Geometry + Annotations ----
+
+def generate_star_points(cx, cy, r, spikes=5):
+    pts = []
+    angle = math.pi / spikes
+    for i in range(2 * spikes):
+        radius = r if i % 2 == 0 else r / 2
+        x = cx + math.cos(i * angle) * radius
+        y = cy + math.sin(i * angle) * radius
+        pts.append([x, y])
+    pts.append(pts[0])
+    return pts
+
+
+def generate_diamond_points(cx, cy, r):
+    return [
+        [cx, cy - r],
+        [cx + r, cy],
+        [cx, cy + r],
+        [cx - r, cy],
+        [cx, cy - r],
+    ]
+
+
+def generate_circle_points(cx, cy, r, segments=12):
+    pts = []
+    for i in range(segments + 1):
+        angle = 2 * math.pi * i / segments
+        x = cx + math.cos(angle) * r
+        y = cy + math.sin(angle) * r
+        pts.append([x, y])
+    return pts
+
+
+def generate_geometry(shape: str, cx: float, cy: float, size: float):
+    if shape == "star":
+        coords = generate_star_points(cx, cy, size)
+    elif shape == "diamond":
+        coords = generate_diamond_points(cx, cy, size)
+    elif shape == "circle":
+        coords = generate_circle_points(cx, cy, size)
+    else:  # rectangle fallback
+        half = size
+        coords = [
+            [cx-half, cy-half],
+            [cx+half, cy-half],
+            [cx+half, cy+half],
+            [cx-half, cy+half],
+            [cx-half, cy-half]
+        ]
+    return {'geojson': {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [coords]
+                },
+                "properties": { "key": "" }
+            }
+        ]
+    },
+    'coords': coords
+    }
+
+
+def geometry_bounds(coords):
+    xs = [pt[0] for pt in coords]
+    ys = [pt[1] for pt in coords]
+    return [min(xs), min(ys), max(xs), max(ys)]
+
+
+def generate_annotation_json(num_frames: int, output_file: Path):
+    """Generate annotation JSON with moving/scaling geometry."""
+    num_tracks = random.randint(3, 5)
+    tracks = {}
+
+    for i in range(num_tracks):
+        track_id = i
+        shape_type = random.choice(["circle", "rectangle", "diamond", "star"])
+        begin = 0
+        end = num_frames - 1
+
+        x, y = random.randint(100, FRAME_WIDTH-100), random.randint(100, FRAME_HEIGHT-100)
+        dx, dy = random.choice([-5, 5]), random.choice([-3, 3])
+        base_size = random.randint(40, 80)
+        growth_rate = random.uniform(0.05, 0.15)
+
+        features = []
+        for frame in range(num_frames):
+            x += dx
+            y += dy
+            if x < 50 or x > FRAME_WIDTH-50:
+                dx *= -1
+                x += dx
+            if y < 50 or y > FRAME_HEIGHT-50:
+                dy *= -1
+                y += dy
+
+            scale = 0.5 * (1 + math.sin(growth_rate * frame))
+            size = base_size * (0.75 + 0.5 * scale)
+
+            output_data = generate_geometry(shape_type, x, y, size)
+            geom = output_data['geojson']
+            coords = output_data['coords']
+            bounds = geometry_bounds(coords)
+
+            feature = {
+                "frame": frame,
+                "bounds": bounds,
+                "keyframe": True,
+                "geometry": geom
+            }
+            features.append(feature)
+
+        tracks[str(track_id)] = {
+            "id": track_id,
+            "meta": {"shape": shape_type},
+            "attributes": {},
+            "confidencePairs": [[fake.word(), float(random.randrange(0, 100)/100)]],
+            "begin": begin,
+            "end": end,
+            "features": features
+        }
+
+    annotation = {
+        "tracks": tracks,
+        "groups": {},
+        "version": 2
+    }
+    with open(output_file, "w") as f:
+        json.dump(annotation, f, indent=2)
+
+
+# ---- Main orchestration ----
+
+@click.command()
+@click.option('--output', '-o', default='./sample', show_default=True,
+              type=click.Path(file_okay=False), help="Base output directory")
+@click.option('--folders', '-f', default=3, show_default=True,
+              help="Number of top-level folders to create")
+@click.option('--max-depth', '-d', default=2, show_default=True,
+              help="Maximum subfolder depth")
+@click.option('--videos', '-v', default=4, show_default=True,
+              help="Number of videos per folder")
+@click.option('--total', '-t', default=50, show_default=True,
+              help="Total number of videos to create")
+@click.option('--duration', default=10, show_default=True,
+              help="Duration (in seconds) of each video")
+def main(output, folders, max_depth, videos, total, duration):
+    base_path = Path(output)
+    base_path.mkdir(parents=True, exist_ok=True)
+
+    # Create one base video
+    base_video = base_path / "base_video.mp4"
+    click.echo(f"Creating base video of {duration}s...")
+    create_base_video(base_video, duration)
+
+    num_frames = duration * FPS
+    count = 0
+    for f in range(folders):
+        if count >= total:
+            break
+        folder_path = base_path / fake.word()
+        folder_path.mkdir(parents=True, exist_ok=True)
+
+        stack = [(folder_path, 1)]
+        while stack and count < total:
+            current_path, depth = stack.pop()
+
+            for _ in range(videos):
+                if count >= total:
+                    break
+                name = fake.word()
+                video_path = current_path / f"{name}.mp4"
+                json_path = current_path / f"{name}.json"
+
+                # Copy base video and create new annotations
+                copy_video_to_new_location(base_video, video_path)
+                generate_annotation_json(num_frames, json_path)
+                count += 1
+
+            if depth < max_depth:
+                for _ in range(2):  # up to 2 subfolders each
+                    subfolder = current_path / fake.word()
+                    subfolder.mkdir(parents=True, exist_ok=True)
+                    stack.append((subfolder, depth+1))
+
+    click.echo(f"Done! Created {count} videos (all {duration}s long, with annotations).")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/assetStoreImport/generateSampleData.py
+++ b/scripts/assetStoreImport/generateSampleData.py
@@ -1,0 +1,373 @@
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "click",
+#     "faker",
+# ]
+# ///
+import csv
+import datetime
+import random
+import subprocess
+import json
+from pathlib import Path
+import click
+from faker import Faker
+import math
+
+fake = Faker()
+
+FRAME_WIDTH = 1280
+FRAME_HEIGHT = 720
+VIDEO_FPS = 30
+
+def create_random_video(file_path: Path, duration: int):
+    """Create a random test video using ffmpeg (MP4 container, H.264 codec)."""
+    cmd = [
+        "ffmpeg", "-y",
+        "-f", "lavfi", "-i", "testsrc=size=1280x720:rate=30",
+        "-t", str(duration),
+        "-c:v", "libx264",
+        "-pix_fmt", "yuv420p",
+        str(file_path)
+    ]
+    subprocess.run(cmd, check=True)
+
+def extract_frames_from_video(video_path: Path, image_dir: Path):
+    """Extract frames from a video and save as sequential JPG files."""
+    image_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "ffmpeg", "-y",
+        "-i", str(video_path),
+        str(image_dir / "frame_%04d.jpg")
+    ]
+    subprocess.run(cmd, check=True)
+
+def generate_star_points(cx, cy, r, spikes=5):
+    """Generate points for a star polygon."""
+    pts = []
+    angle = math.pi / spikes
+    for i in range(2 * spikes):
+        radius = r if i % 2 == 0 else r / 2
+        x = cx + math.cos(i * angle) * radius
+        y = cy + math.sin(i * angle) * radius
+        pts.append([x, y])
+    pts.append(pts[0])  # close polygon
+    return pts
+
+def generate_diamond_points(cx, cy, r):
+    return [
+        [cx, cy - r],
+        [cx + r, cy],
+        [cx, cy + r],
+        [cx - r, cy],
+        [cx, cy - r],
+    ]
+
+def generate_circle_points(cx, cy, r, segments=12):
+    pts = []
+    for i in range(segments+1):
+        angle = 2 * math.pi * i / segments
+        x = cx + math.cos(angle) * r
+        y = cy + math.sin(angle) * r
+        pts.append([x, y])
+    return pts
+
+def generate_geometry(shape: str, cx: float, cy: float, size: float):
+    """Return GeoJSON polygon of the shape centered at (cx, cy)."""
+    if shape == "star":
+        coords = generate_star_points(cx, cy, size)
+    elif shape == "diamond":
+        coords = generate_diamond_points(cx, cy, size)
+    elif shape == "circle":
+        coords = generate_circle_points(cx, cy, size)
+    else:  # rectangle fallback
+        half = size
+        coords = [
+            [cx-half, cy-half],
+            [cx+half, cy-half],
+            [cx+half, cy+half],
+            [cx-half, cy+half],
+            [cx-half, cy-half]
+        ]
+    return {'geojson': {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type" :"Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [coords]
+                },
+                "properties": { "key": "" }
+            }
+        ]
+    },
+    'coords': coords
+    }
+
+def geometry_bounds(coords):
+    """Calculate bounding box [x1, y1, x2, y2] from polygon points."""
+    xs = [pt[0] for pt in coords]
+    ys = [pt[1] for pt in coords]
+    return [min(xs), min(ys), max(xs), max(ys)]
+
+def build_tracks(num_frames: int):
+    """Build track dict keyed by string id (DIVE annotation schema)."""
+    num_tracks = random.randint(3, 5)
+    tracks = {}
+
+    for i in range(num_tracks):
+        track_id = i
+        shape_type = random.choice(["circle", "rectangle", "diamond", "star"])
+        begin = 0
+        end = num_frames - 1
+
+        x, y = random.randint(100, FRAME_WIDTH - 100), random.randint(100, FRAME_HEIGHT - 100)
+        dx, dy = random.choice([-5, 5]), random.choice([-3, 3])
+        base_size = random.randint(40, 80)
+        growth_rate = random.uniform(0.05, 0.15)
+
+        features = []
+        for frame in range(num_frames):
+            x += dx
+            y += dy
+            if x < 50 or x > FRAME_WIDTH - 50:
+                dx *= -1
+                x += dx
+            if y < 50 or y > FRAME_HEIGHT - 50:
+                dy *= -1
+                y += dy
+
+            scale = 0.5 * (1 + math.sin(growth_rate * frame))
+            size = base_size * (0.75 + 0.5 * scale)
+
+            output_data = generate_geometry(shape_type, x, y, size)
+            geom = output_data['geojson']
+            coords = output_data['coords']
+            bounds = geometry_bounds(coords)
+
+            features.append({
+                "frame": frame,
+                "bounds": bounds,
+                "keyframe": True,
+                "geometry": geom,
+            })
+
+        tracks[str(track_id)] = {
+            "id": track_id,
+            "meta": {"shape": shape_type},
+            "attributes": {},
+            "confidencePairs": [[fake.word(), float(random.randrange(0, 100) / 100)]],
+            "begin": begin,
+            "end": end,
+            "features": features,
+        }
+
+    return tracks
+
+
+def _viame_timestamp(frame: int, fps: int) -> str:
+    return datetime.datetime.fromtimestamp(
+        frame / fps, datetime.timezone.utc
+    ).strftime(r'%H:%M:%S.%f')
+
+
+def _append_viame_geometry_columns(columns: list, geometry: dict):
+    """Append (poly) tokens for polygon geometry (VIAME CSV format)."""
+    if not geometry or geometry.get("type") != "FeatureCollection":
+        return
+    for geo_feature in geometry.get("features", []):
+        geom = geo_feature.get("geometry", {})
+        if geom.get("type") != "Polygon":
+            continue
+        coordinates = [
+            coord
+            for ring in geom.get("coordinates", [])
+            for point in ring
+            for coord in point
+        ]
+        columns.append(f"(poly) {' '.join(str(round(c)) for c in coordinates)}")
+
+
+def generate_annotation_viame_csv(
+    tracks: dict,
+    output_file: Path,
+    *,
+    fps: int = VIDEO_FPS,
+    frame_filenames: list = None,
+):
+    """Write tracks as a VIAME CSV annotation file."""
+    with open(output_file, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "# 1: Detection or Track-id",
+            "2: Video or Image Identifier",
+            "3: Unique Frame Identifier",
+            "4-7: Img-bbox(TL_x",
+            "TL_y",
+            "BR_x",
+            "BR_y)",
+            "8: Detection or Length Confidence",
+            "9: Target Length (0 or -1 if invalid)",
+            "10-11+: Repeated Species",
+            "Confidence Pairs or Attributes",
+        ])
+        writer.writerow(["# metadata", f"fps: {json.dumps(fps)}"])
+
+        for track in tracks.values():
+            confidence_pairs = sorted(
+                track["confidencePairs"], key=lambda item: item[1], reverse=True
+            )
+            for feature in track["features"]:
+                columns = [
+                    track["id"],
+                    "",
+                    feature["frame"],
+                    *[round(v) for v in feature["bounds"]],
+                    confidence_pairs[0][1],
+                    -1,
+                ]
+                if frame_filenames is not None and feature["frame"] < len(frame_filenames):
+                    columns[1] = frame_filenames[feature["frame"]]
+                elif fps:
+                    columns[1] = _viame_timestamp(feature["frame"], fps)
+
+                for pair in confidence_pairs:
+                    columns.extend(pair)
+
+                _append_viame_geometry_columns(columns, feature.get("geometry"))
+                writer.writerow(columns)
+
+
+def generate_annotation_json(tracks: dict, output_file: Path):
+    """Write tracks as a DIVE track JSON annotation file."""
+    annotation = {
+        "tracks": tracks,
+        "groups": {},
+        "version": 2,
+    }
+    with open(output_file, "w") as f:
+        json.dump(annotation, f, indent=2)
+
+
+def write_annotations(
+    num_frames: int,
+    output_file: Path,
+    *,
+    use_viame_csv: bool,
+    frame_filenames: list = None,
+):
+    """Write annotations as either DIVE JSON or VIAME CSV."""
+    tracks = build_tracks(num_frames)
+    if use_viame_csv:
+        generate_annotation_viame_csv(
+            tracks, output_file, frame_filenames=frame_filenames
+        )
+    else:
+        generate_annotation_json(tracks, output_file)
+
+def create_video_content(base_dir: Path, max_videos: int, counter: dict, total: int):
+    """Create videos and associated JSON or VIAME CSV annotations."""
+    if counter['count'] >= total:
+        return
+    num_videos = random.randint(1, max_videos)
+    for _ in range(num_videos):
+        if counter['count'] >= total:
+            break
+        duration = random.randint(5, 30)
+        name = fake.word() + ".mp4"
+        video_path = base_dir / name
+        create_random_video(video_path, duration)
+        counter['count'] += 1
+
+        use_viame_csv = random.choice([True, False])
+        ext = ".csv" if use_viame_csv else ".json"
+        write_annotations(
+            duration * VIDEO_FPS,
+            video_path.with_suffix(ext),
+            use_viame_csv=use_viame_csv,
+        )
+
+def create_image_sequence_content(base_dir: Path, counter: dict, total: int):
+    """Create image sequence from a temporary video and generate JSON or VIAME CSV annotations."""
+    if counter['count'] >= total:
+        return
+    duration = random.randint(5, 30)
+    tmp_video = base_dir / (fake.word() + "_tmp.mp4")
+    create_random_video(tmp_video, duration)
+    seq_folder = base_dir / (tmp_video.stem.replace("_tmp", "") + "_frames")
+    extract_frames_from_video(tmp_video, seq_folder)
+    tmp_video.unlink()
+    counter['count'] += 1
+
+    num_frames = duration * VIDEO_FPS
+    frame_filenames = [p.name for p in sorted(seq_folder.glob("frame_*.jpg"))]
+    use_viame_csv = random.choice([True, False])
+    ext = ".csv" if use_viame_csv else ".json"
+    annotation_file = seq_folder / (seq_folder.stem + ext)
+    write_annotations(
+        num_frames,
+        annotation_file,
+        use_viame_csv=use_viame_csv,
+        frame_filenames=frame_filenames if use_viame_csv else None,
+    )
+
+def create_folder_structure(base_dir: Path, depth: int, max_depth: int,
+                            max_videos: int, counter: dict, total: int):
+    """Recursively create folders with either videos or image sequences."""
+    if counter['count'] >= total:
+        return
+
+    content_type = random.choice(["video", "images"])
+    if content_type == "video":
+        create_video_content(base_dir, max_videos, counter, total)
+    else:
+        create_image_sequence_content(base_dir, counter, total)
+
+    if counter['count'] >= total:
+        return
+
+    num_subfolders = random.randint(0, 3)
+    for _ in range(num_subfolders):
+        if counter['count'] >= total:
+            break
+        subfolder = base_dir / fake.word()
+        subfolder.mkdir(parents=True, exist_ok=True)
+        if depth < max_depth:
+            create_folder_structure(subfolder, depth+1, max_depth, max_videos, counter, total)
+        else:
+            leaf_type = random.choice(["video", "images"])
+            if leaf_type == "video":
+                create_video_content(subfolder, max_videos, counter, total)
+            else:
+                create_image_sequence_content(subfolder, counter, total)
+
+@click.command()
+@click.option('--output', '-o', default='./sample', show_default=True,
+              type=click.Path(file_okay=False), help="Base output directory")
+@click.option('--folders', '-f', default=3, show_default=True,
+              help="Number of top-level folders to create")
+@click.option('--max-depth', '-d', default=2, show_default=True,
+              help="Maximum subfolder depth")
+@click.option('--videos', '-v', default=2, show_default=True,
+              help="Maximum videos per folder")
+@click.option('--total', '-t', default=10, show_default=True,
+              help="Total number of datasets (videos or image sequences)")
+def main(output, folders, max_depth, videos, total):
+    base_path = Path(output)
+    base_path.mkdir(parents=True, exist_ok=True)
+
+    counter = {'count': 0}
+    click.echo(f"Generating up to {total} datasets in {base_path}...")
+    for _ in range(folders):
+        if counter['count'] >= total:
+            break
+        folder_path = base_path / fake.word()
+        folder_path.mkdir(parents=True, exist_ok=True)
+        create_folder_structure(folder_path, 1, max_depth, videos, counter, total)
+
+    click.echo(f"Done! Created {counter['count']} datasets.")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/assetStoreImport/minIOConfig.py
+++ b/scripts/assetStoreImport/minIOConfig.py
@@ -31,11 +31,13 @@ def get_container_ip(container_name: str, network_name: str) -> str:
 @click.command()
 @click.option('--data-dir', '-d', default='./sample', show_default=True,
               type=click.Path(file_okay=False), help="Folder to host in MinIO bucket")
+@click.option('--expose', is_flag=True, default=False,
+              help="Publish MinIO ports on the host (off by default; only reachable on dive-dsa_default)")
 @click.option('--api-port', default=9000, show_default=True,
-              help="Port for S3 API access")
+              help="Host port for S3 API when --expose is set")
 @click.option('--console-port', default=9001, show_default=True,
-              help="Port for MinIO Console access")
-def main(data_dir, api_port, console_port):
+              help="Host port for MinIO Console when --expose is set")
+def main(data_dir, expose, api_port, console_port):
     """
     Launch MinIO and a persistent mc container, configure a bucket and user.
     """
@@ -58,18 +60,25 @@ def main(data_dir, api_port, console_port):
                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     # Start MinIO server
-    click.echo(f"🚀 Starting MinIO server with data dir: {data_dir}")
-    subprocess.run([
+    expose_msg = " (host ports published)" if expose else " (docker network only)"
+    click.echo(f"🚀 Starting MinIO server with data dir: {data_dir}{expose_msg}")
+    minio_run = [
         "docker", "run", "-d",
         "--name", minio_container,
         "--network", "dive-dsa_default",
-        "-p", f"{api_port}:9000",
-        "-p", f"{console_port}:9001",
+    ]
+    if expose:
+        minio_run.extend([
+            "-p", f"{api_port}:9000",
+            "-p", f"{console_port}:9001",
+        ])
+    minio_run.extend([
         "-e", "MINIO_ROOT_USER=rootuser",
         "-e", "MINIO_ROOT_PASSWORD=rootpass123",
         "minio/minio",
-        "server", "/data", "--console-address", ":9001"
-    ], check=True)
+        "server", "/data", "--console-address", ":9001",
+    ])
+    subprocess.run(minio_run, check=True)
 
     # Give MinIO time to start
     click.echo("⏳ Waiting for MinIO server to start...")
@@ -103,7 +112,6 @@ def main(data_dir, api_port, console_port):
         )
         return result.stdout if capture_output else None
 
-    localhost = "localhost"
     # Configure alias for root user
     mc_cmd("alias", "set", "local", f"http://{minio_ip}:9000", "rootuser", "rootpass123")
 
@@ -152,12 +160,15 @@ def main(data_dir, api_port, console_port):
     # shutdown the client server
     subprocess.run(["docker", "stop", mc_container], check=True)
     subprocess.run(["docker", "rm", mc_container], check=True)
-    click.echo(f"\n✅ MinIO setup complete!\n")
-    click.echo(f"  Console: http://{localhost}:{console_port} (user: rootuser / rootpass123)")
-    click.echo(f"  S3 API:  http://{minio_container}:{api_port}")
-    click.echo(f"  S3 API:  http://{minio_ip}:{api_port}")
+    click.echo("\n✅ MinIO setup complete!\n")
+    click.echo(f"  S3 API:  http://{minio_container}:9000 (dive-dsa_default)")
+    click.echo(f"  S3 API:  http://{minio_ip}:9000 (dive-dsa_default)")
+    if expose:
+        click.echo(f"  Console (host): http://localhost:{console_port} (user: rootuser / rootpass123)")
+        click.echo(f"  S3 API (host):  http://localhost:{api_port}")
+    else:
+        click.echo("  Host access: not published (pass --expose to map ports to localhost)")
     click.echo(f"  Bucket: {bucket_name}")
-    click.echo(f"  Persistent mc client running as container: {mc_container}")
 
 if __name__ == "__main__":
     main()

--- a/scripts/assetStoreImport/minIOConfig.py
+++ b/scripts/assetStoreImport/minIOConfig.py
@@ -1,0 +1,163 @@
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "click",
+# ]
+# ///
+import subprocess
+import time
+import click
+import os
+import json
+from pathlib import Path
+
+AccessKey = "OMKF2I2NOD7JGYZ9XHE3"
+SecretKey = "xbze+fJ6Wrfplq17JjSCZZJSz7AxEwRWm1MZXH2O"
+
+
+def get_container_ip(container_name: str, network_name: str) -> str:
+    result = subprocess.run(
+        ["docker", "inspect", container_name],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+    info = json.loads(result.stdout)
+    # Navigate to the network you care about
+    ip_address = info[0]["NetworkSettings"]["Networks"][network_name]["IPAddress"]
+    return ip_address
+
+
+@click.command()
+@click.option('--data-dir', '-d', default='./sample', show_default=True,
+              type=click.Path(file_okay=False), help="Folder to host in MinIO bucket")
+@click.option('--api-port', default=9000, show_default=True,
+              help="Port for S3 API access")
+@click.option('--console-port', default=9001, show_default=True,
+              help="Port for MinIO Console access")
+def main(data_dir, api_port, console_port):
+    """
+    Launch MinIO and a persistent mc container, configure a bucket and user.
+    """
+    data_dir = Path(data_dir).resolve()
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    minio_container = "minio_server"
+    mc_container = "minio_client"
+
+    uid = os.getuid()
+    gid = os.getgid()
+
+    # Stop/remove existing containers
+    for c in [minio_container, mc_container]:
+        subprocess.run(["docker", "rm", "-f", c],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    # Create a shared Docker network
+    subprocess.run(["docker", "network", "create", "dive-dsa_default"],
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    # Start MinIO server
+    click.echo(f"🚀 Starting MinIO server with data dir: {data_dir}")
+    subprocess.run([
+        "docker", "run", "-d",
+        "--name", minio_container,
+        "--network", "dive-dsa_default",
+        "-p", f"{api_port}:9000",
+        "-p", f"{console_port}:9001",
+        "-e", "MINIO_ROOT_USER=rootuser",
+        "-e", "MINIO_ROOT_PASSWORD=rootpass123",
+        "minio/minio",
+        "server", "/data", "--console-address", ":9001"
+    ], check=True)
+
+    # Give MinIO time to start
+    click.echo("⏳ Waiting for MinIO server to start...")
+    time.sleep(5)
+
+    mc_config_dir = Path.home() / ".mc"
+    mc_config_dir.mkdir(parents=True, exist_ok=True)
+    # Ensure ownership
+    os.chown(mc_config_dir, uid, gid)
+
+    # Start persistent mc container with config volume
+    click.echo("⚙️ Starting persistent mc client container...")
+    subprocess.run([
+        "docker", "run", "-dit",
+        "--name", mc_container,
+        "--network", "dive-dsa_default",
+        "-v", f"{data_dir}:/data",
+        "--entrypoint=/bin/sh",
+        "minio/mc",
+    ], check=True)
+
+    minio_ip = get_container_ip(minio_container, "dive-dsa_default")
+    # Helper function: run mc inside persistent container
+    
+    def mc_cmd(*args, capture_output=False):
+        result = subprocess.run(
+            ["docker", "exec", mc_container, "mc", *args],
+            check=True,
+            text=True,
+            capture_output=capture_output
+        )
+        return result.stdout if capture_output else None
+
+    localhost = "localhost"
+    # Configure alias for root user
+    mc_cmd("alias", "set", "local", f"http://{minio_ip}:9000", "rootuser", "rootpass123")
+
+    # Create a bucket
+    bucket_name = "dive-sample-data"
+    # check if bucket exists
+    existing_buckets = mc_cmd("ls", "local", capture_output=True)
+    if bucket_name in existing_buckets:
+        click.echo(f"🗃️ Bucket {bucket_name} already exists, skipping creation.")
+    else:
+        click.echo(f"🗃️ Creating bucket: {bucket_name} ...")
+        mc_cmd("mb", f"local/{bucket_name}")
+
+    # Load sample data into bucket
+    click.echo(f"📂 Uploading sample data from {data_dir} to bucket...")
+    mc_cmd("cp", "-r", "/data/.", f"local/{bucket_name}")
+
+    # Create a new access key under rootuser
+    output = mc_cmd("admin", "accesskey", "ls", "local", "rootuser", capture_output=True)
+    has_existing_key = False
+    if output:
+        lines = output.strip().splitlines()
+        print(output)
+        for line in lines:
+            if "AccessKey" in line:
+                parts = line.split()
+                print(parts)
+                has_existing_key = True
+
+    if not has_existing_key:
+        click.echo("🔑 Creating a new access key...")
+        mc_cmd("admin", "accesskey", "create", "local", "rootuser", "--access-key", AccessKey, "--secret-key", SecretKey)
+
+    # Smoke test the new credentials
+    alias_name = "smoketest"
+    click.echo("🧪 Running smoke test with new access key...")
+    try:
+        mc_cmd("alias", "set", alias_name, f"http://{minio_ip}:9000", AccessKey, SecretKey)
+        mc_cmd("ls", alias_name)  # list buckets
+        click.echo("✅ Smoke test passed! New access key works.")
+    except subprocess.CalledProcessError:
+        click.echo("❌ Smoke test failed! Could not use new access key.")
+
+    # remove the smoketest alias
+    mc_cmd("alias", "rm", alias_name)
+    # shutdown the client server
+    subprocess.run(["docker", "stop", mc_container], check=True)
+    subprocess.run(["docker", "rm", mc_container], check=True)
+    click.echo(f"\n✅ MinIO setup complete!\n")
+    click.echo(f"  Console: http://{localhost}:{console_port} (user: rootuser / rootpass123)")
+    click.echo(f"  S3 API:  http://{minio_container}:{api_port}")
+    click.echo(f"  S3 API:  http://{minio_ip}:{api_port}")
+    click.echo(f"  Bucket: {bucket_name}")
+    click.echo(f"  Persistent mc client running as container: {mc_container}")
+
+if __name__ == "__main__":
+    main()

--- a/server/dive_server/views_metadata.py
+++ b/server/dive_server/views_metadata.py
@@ -12,6 +12,7 @@ from girder.api.rest import Resource, getApiUrl, setRawResponse, setResponseHead
 from girder.constants import AccessType
 from girder.exceptions import RestException
 from girder.models.file import File
+from girder.models.collection import Collection
 from girder.models.folder import Folder
 from girder.models.item import Item
 from girder.models.setting import Setting
@@ -478,6 +479,221 @@ def refresh_metadata_keys_stats_from_stored_dive_metadata(root_folder, categoric
     DIVE_MetadataKeys().save(keys_doc)
 
 
+_CREATE_METADATA_DISPLAY_DEFAULT = {
+    "display": ['DIVE_DatasetId', 'DIVE_Name'],
+    "hide": [""],
+}
+_CREATE_METADATA_FFPROBE_DEFAULT = {
+    "import": True,
+    "keys": ["width", "height", "display_aspect_ratio", "nb_frames", "duration"],
+}
+
+
+def _is_dive_metadata_folder(folder) -> bool:
+    return folder.get('meta', {}).get(DIVEMetadataMarker) in TRUTHY_META_VALUES
+
+
+def _find_existing_dive_metadata_child(parent_folder, user):
+    """Return a direct child folder already marked as DIVE metadata, if any."""
+    for child in Folder().childFolders(parent_folder, 'folder', user=user):
+        if _is_dive_metadata_folder(child):
+            return child
+    return None
+
+
+def _load_girder_folder_parent(folder, user):
+    """
+    Return the immediate Girder parent model and parentType for a folder.
+
+    Nested folders may still carry collection ancestry in ``parentCollection``; resolve
+    the direct parent by loading ``parentId`` as a folder first, then as a collection.
+    """
+    parent_id = folder.get('parentId')
+    if not parent_id:
+        return None, None
+    parent_folder = Folder().load(
+        str(parent_id),
+        level=AccessType.WRITE,
+        user=user,
+        force=True,
+    )
+    if parent_folder is not None:
+        return parent_folder, 'folder'
+    parent_collection = Collection().load(
+        str(parent_id),
+        level=AccessType.WRITE,
+        user=user,
+        force=True,
+    )
+    if parent_collection is not None:
+        return parent_collection, 'collection'
+    return None, None
+
+
+def _metadata_folder_name_for_dataset_folder(dataset_folder, name_suffix):
+    return f"{dataset_folder['name']} - {name_suffix}"
+
+
+def _find_existing_dive_metadata_sibling(dataset_folder, user, metadata_name):
+    """Return a sibling metadata folder (same parent as ``dataset_folder``), if any."""
+    parent, parent_type = _load_girder_folder_parent(dataset_folder, user)
+    if parent is None:
+        return None
+    for sibling in Folder().childFolders(parent, parent_type, user=user):
+        if not _is_dive_metadata_folder(sibling):
+            continue
+        if sibling['name'] == metadata_name:
+            return sibling
+    return None
+
+
+def _create_dive_metadata_sibling_folder(dataset_folder, metadata_name, user):
+    """Create a DIVE metadata folder next to ``dataset_folder`` (not inside it)."""
+    parent, parent_type = _load_girder_folder_parent(dataset_folder, user)
+    if parent is None:
+        raise RestException(
+            f'Could not resolve parent for folder "{dataset_folder.get("name", "")}"',
+            code=400,
+        )
+    return Folder().createFolder(parent, metadata_name, parentType=parent_type)
+
+
+def _folder_has_recursive_datasets(folder, user) -> bool:
+    probe: list = []
+    crud_dataset.get_recursive_datasets(folder, user, probe, limit=1)
+    return len(probe) > 0
+
+
+def _normalize_create_metadata_configs(displayConfig, ffprobeMetadata):
+    display_config = _normalize_metadata_config(displayConfig, _CREATE_METADATA_DISPLAY_DEFAULT)
+    ffprobe_metadata = _normalize_metadata_config(ffprobeMetadata, _CREATE_METADATA_FFPROBE_DEFAULT)
+    return display_config, ffprobe_metadata
+
+
+def _build_default_dataset_metadata_row(item, user, ffprobe_metadata):
+    data = {
+        'DIVE_DatasetId': str(item['_id']),
+        'DIVE_Name': str(item['lowerName']),
+        'DIVE_Path': path_util.getResourcePath('folder', item, user=user),
+    }
+    if ffprobe_metadata.get('import', False):
+        ffmetadata = item.get('meta', {}).get('ffprobe_info', {})
+        ffkeys = ffprobe_metadata.get('keys', [])
+        for ff_metadata_key in ffkeys:
+            if ffmetadata.get(ff_metadata_key) is not None:
+                raw_value = ffmetadata[ff_metadata_key]
+                try:
+                    data[f'ffprobe_{ff_metadata_key}'] = float(raw_value)
+                except (ValueError, TypeError):
+                    data[f'ffprobe_{ff_metadata_key}'] = str(raw_value)
+    sanitize_value_tree_for_girder_json(data, minmax_keys_to_zero=False)
+    return data
+
+
+def _apply_dive_metadata_folder_marker(base_folder, display_config, categorical_limit):
+    base_folder['meta'][DIVEMetadataMarker] = True
+    display_config['categoricalLimit'] = categorical_limit
+    if display_config.get('hide', False) is False:
+        display_config['hide'] = [""]
+    _ensure_filter_lists_in_display_config(display_config)
+    base_folder['meta'][DIVEMetadataFilter] = display_config
+    Folder().save(base_folder)
+
+
+def _populate_dive_metadata_folder(
+    base_folder,
+    root_folder,
+    user,
+    display_config,
+    ffprobe_metadata,
+    categorical_limit,
+    replace_metadata=False,
+):
+    """
+    Index datasets under ``root_folder`` into ``base_folder``.
+
+    When ``replace_metadata`` is false, existing per-dataset rows and schema docs are left
+    unchanged; only missing datasets are added and key stats are refreshed if needed.
+    """
+    dataset_list = []
+    crud_dataset.get_recursive_datasets(root_folder, user, dataset_list)
+    added = 0
+    existing_count = 0
+    metadata_keys = {}
+    root_id = str(base_folder['_id'])
+    for item in dataset_list:
+        data = _build_default_dataset_metadata_row(item, user, ffprobe_metadata)
+        existing_row = DIVE_Metadata().findOne(
+            {'DIVEDataset': str(item['_id']), 'root': root_id}
+        )
+        if existing_row and not replace_metadata:
+            existing_count += 1
+            continue
+        DIVE_Metadata().createMetadata(
+            item,
+            base_folder,
+            user,
+            data,
+            replace=replace_metadata or existing_row is None,
+        )
+        added += 1
+        _accumulate_flat_metadata_key_stats(metadata_keys, data)
+
+    keys_doc = DIVE_MetadataKeys().findOne({'root': root_id})
+    if replace_metadata or keys_doc is None:
+        _finalize_metadata_keys_categories(metadata_keys, categorical_limit)
+        DIVE_MetadataKeys().createMetadataKeys(
+            base_folder,
+            user,
+            metadata_keys,
+            replace=replace_metadata or keys_doc is None,
+        )
+    elif added > 0:
+        refresh_metadata_keys_stats_from_stored_dive_metadata(base_folder, categorical_limit)
+
+    if not _is_dive_metadata_folder(base_folder):
+        _apply_dive_metadata_folder_marker(base_folder, display_config, categorical_limit)
+
+    return {
+        'added': added,
+        'existing': existing_count,
+        'datasetCount': len(dataset_list),
+        'metadataKeys': metadata_keys,
+    }
+
+
+def _resolve_create_metadata_targets(resource_id, resource_type, user):
+    if resource_type == 'collection':
+        collection = Collection().load(
+            resource_id,
+            level=AccessType.WRITE,
+            user=user,
+            force=True,
+        )
+        if collection is None:
+            raise RestException('Collection not found', code=404)
+        return collection, 'collection'
+
+    folder = Folder().load(
+        resource_id,
+        level=AccessType.WRITE,
+        user=user,
+        force=True,
+    )
+    if folder is None:
+        raise RestException('Folder not found', code=404)
+    if _is_dive_metadata_folder(folder):
+        raise RestException(
+            'Cannot create metadata inside an existing DIVE metadata folder',
+            code=400,
+        )
+    return folder, 'folder'
+
+
+def _list_immediate_child_folders(parent, parent_type, user):
+    return list(Folder().childFolders(parent, parent_type, user=user))
+
+
 def _bulk_import_row_is_matcher_key(key):
     """True for columns used only to locate a row (never stored via updateKey)."""
     return isinstance(key, str) and key.lower() in _BULK_IMPORT_SKIP_KEYS
@@ -655,6 +871,7 @@ class DIVEMetadata(Resource):
             self.filter_folder,
         )
         self.route("POST", ("create_metadata_folder", ":id"), self.create_metadata_folder)
+        self.route("POST", ("create_metadata_recursive",), self.create_metadata_recursive)
         self.route("POST", (':id', "clone_filter"), self.clone_filter)
         self.route("GET", (':id', 'metadata_keys'), self.get_metadata_keys)
         self.route("GET", (':id', 'metadata_filter_values'), self.get_metadata_filter)
@@ -972,75 +1189,251 @@ class DIVEMetadata(Resource):
     def create_metadata_folder(
         self, folder, name, rootFolderId, displayConfig, ffprobeMetadata, categoricalLimit
     ):
-        # Process the current folder for the specified fileType using the matcher to generate DIVE_Metadata
-        # make sure the folder is set to a DIVE Metadata folder using DIVE_METADATA = True
         user = self.getCurrentUser()
-
-        base_folder = Folder().createFolder(folder, name)
-        data = None
-        errorLog = []
-        added = 0
-        metadataKeys = {}
-        datasetList = []
-        rootFolder = Folder().load(
+        metadata_folder = _find_existing_dive_metadata_child(folder, user)
+        base_folder = metadata_folder or Folder().createFolder(folder, name)
+        root_folder = Folder().load(
             rootFolderId,
             level=AccessType.WRITE,
             user=user,
             force=True,
         )
-        displayConfig = _normalize_metadata_config(
+        display_config, ffprobe_metadata = _normalize_create_metadata_configs(
             displayConfig,
-            {
-                "display": ['DIVE_DatasetId', 'DIVE_Name'],
-                "hide": [""],
-            },
-        )
-        ffprobeMetadata = _normalize_metadata_config(
             ffprobeMetadata,
-            {
-                "import": True,
-                "keys": ["width", "height", "display_aspect_ratio", "nb_frames", "duration"],
-            },
         )
-        crud_dataset.get_recursive_datasets(rootFolder, user, datasetList)
-
-        for item in datasetList:
-            data = {}
-            data['DIVE_DatasetId'] = str(item['_id'])
-            data['DIVE_Name'] = str(item['lowerName'])
-            resource_path = path_util.getResourcePath('folder', item, user=user)
-            data['DIVE_Path'] = resource_path
-            if ffprobeMetadata.get('import', False):  # Add in ffprobe metadata to the system
-                ffmetadata = item.get('meta', {}).get('ffprobe_info', {})
-                ffkeys = ffprobeMetadata.get('keys', [])
-                for ffMetadataKey in ffkeys:
-                    if ffmetadata.get(ffMetadataKey) is not None:
-                        raw_value = ffmetadata[ffMetadataKey]
-                        try:
-                            data[f'ffprobe_{ffMetadataKey}'] = float(raw_value)
-                        except (ValueError, TypeError):
-                            data[f'ffprobe_{ffMetadataKey}'] = str(raw_value)
-            sanitize_value_tree_for_girder_json(data, minmax_keys_to_zero=False)
-            DIVE_Metadata().createMetadata(item, base_folder, user, data)
-            _accumulate_flat_metadata_key_stats(metadataKeys, data)
-
-            # now we need to determine what is categorical vs what is a search field
-        _finalize_metadata_keys_categories(metadataKeys, categoricalLimit)
-        DIVE_MetadataKeys().createMetadataKeys(base_folder, user, metadataKeys)
-        # add metadata to root folder for
-        base_folder['meta'][DIVEMetadataMarker] = True
-        displayConfig['categoricalLimit'] = categoricalLimit
-        if displayConfig.get('hide', False) is False:
-            displayConfig['hide'] = [""]
-        _ensure_filter_lists_in_display_config(displayConfig)
-        base_folder['meta'][DIVEMetadataFilter] = displayConfig
-        Folder().save(base_folder)
+        populate_result = _populate_dive_metadata_folder(
+            base_folder,
+            root_folder,
+            user,
+            display_config,
+            ffprobe_metadata,
+            categoricalLimit,
+            replace_metadata=False,
+        )
+        added = populate_result['added']
 
         return {
-            "results": f"added {added} folders",
-            "errors": errorLog,
-            "metadataKeys": metadataKeys,
+            "results": f"added {added} datasets",
+            "errors": [],
+            "metadataKeys": populate_result['metadataKeys'],
             "folderId": str(base_folder['_id']),
+            "existing": populate_result['existing'],
+        }
+
+    @access.user
+    @autoDescribeRoute(
+        Description(
+            "Create DIVE metadata for a Girder collection or folder. "
+            "Can create one metadata folder for the whole resource or one per immediate subfolder. "
+            "Existing DIVE metadata folders and per-dataset rows are not replaced."
+        )
+        .param(
+            "resourceId",
+            "Folder or collection ID to scan for DIVE datasets",
+            paramType="formData",
+            dataType="string",
+            required=True,
+        )
+        .param(
+            "resourceType",
+            "Girder resource type: folder or collection",
+            paramType="formData",
+            dataType="string",
+            default="folder",
+            required=False,
+        )
+        .param(
+            "scope",
+            "single: one metadata folder for all datasets under the resource; "
+            "subfolders: one metadata folder per immediate child folder, created as a sibling of that folder",
+            paramType="formData",
+            dataType="string",
+            default="subfolders",
+            required=False,
+        )
+        .param(
+            "name",
+            "Metadata folder name (single scope) or name suffix (subfolders: '<child> - <name>')",
+            paramType="formData",
+            dataType="string",
+            default="DIVE Metadata",
+            required=False,
+        )
+        .param(
+            "parentFolderId",
+            "Parent folder for a new metadata folder in single scope (defaults to resourceId when resource is a folder)",
+            paramType="formData",
+            dataType="string",
+            required=False,
+        )
+        .jsonParam(
+            "displayConfig",
+            "List of Main Display Keys for the metadata and keys to hide from the filter",
+            required=True,
+            default=_CREATE_METADATA_DISPLAY_DEFAULT,
+        )
+        .jsonParam(
+            "ffprobeMetadata",
+            "List Metadata keys to extract from the ffprobe metadata from videos",
+            required=True,
+            default=_CREATE_METADATA_FFPROBE_DEFAULT,
+        )
+        .param(
+            "categoricalLimit",
+            "Above this number make a field a search field instead of a dropdown",
+            paramType="formData",
+            dataType="integer",
+            default=50,
+        )
+    )
+    def create_metadata_recursive(
+        self,
+        resourceId,
+        resourceType,
+        scope,
+        name,
+        parentFolderId,
+        displayConfig,
+        ffprobeMetadata,
+        categoricalLimit,
+    ):
+        user = self.getCurrentUser()
+        resource_type = (resourceType or 'folder').strip().lower()
+        if resource_type not in ('folder', 'collection'):
+            raise RestException('resourceType must be folder or collection', code=400)
+        scope_norm = (scope or 'subfolders').strip().lower()
+        if scope_norm not in ('single', 'subfolders'):
+            raise RestException('scope must be single or subfolders', code=400)
+
+        resource, parent_type = _resolve_create_metadata_targets(resourceId, resource_type, user)
+        display_config, ffprobe_metadata = _normalize_create_metadata_configs(
+            displayConfig,
+            ffprobeMetadata,
+        )
+        created = []
+        existing_results = []
+        errors = []
+
+        if scope_norm == 'single':
+            if resource_type == 'collection':
+                parent = resource
+                parent_folder_type = 'collection'
+                scan_roots = _list_immediate_child_folders(resource, 'collection', user)
+            else:
+                parent = Folder().load(
+                    parentFolderId or resourceId,
+                    level=AccessType.WRITE,
+                    user=user,
+                    force=True,
+                )
+                parent_folder_type = 'folder'
+                scan_roots = [resource]
+
+            metadata_folder = _find_existing_dive_metadata_child(parent, user)
+            reused_existing = metadata_folder is not None
+            base_folder = metadata_folder or Folder().createFolder(
+                parent, name, parentType=parent_folder_type
+            )
+            populate_result = {'added': 0, 'existing': 0}
+            if resource_type == 'collection':
+                if not scan_roots:
+                    errors.append(f'No folders under collection {resource["name"]}')
+                for child in scan_roots:
+                    extra = _populate_dive_metadata_folder(
+                        base_folder,
+                        child,
+                        user,
+                        display_config,
+                        ffprobe_metadata,
+                        categoricalLimit,
+                        replace_metadata=False,
+                    )
+                    populate_result['added'] += extra['added']
+                    populate_result['existing'] += extra['existing']
+            else:
+                populate_result = _populate_dive_metadata_folder(
+                    base_folder,
+                    resource,
+                    user,
+                    display_config,
+                    ffprobe_metadata,
+                    categoricalLimit,
+                    replace_metadata=False,
+                )
+            entry = {
+                'rootFolderId': str(resource['_id']),
+                'metadataFolderId': str(base_folder['_id']),
+                'added': populate_result['added'],
+                'existing': populate_result['existing'],
+            }
+            if reused_existing:
+                entry['reusedExisting'] = True
+            if reused_existing and populate_result['added'] == 0:
+                existing_results.append({**entry, 'reason': 'existing_metadata_folder'})
+            else:
+                created.append(entry)
+        else:
+            child_folders = _list_immediate_child_folders(resource, parent_type, user)
+            for child in child_folders:
+                if _is_dive_metadata_folder(child):
+                    existing_results.append(
+                        {
+                            'rootFolderId': str(child['_id']),
+                            'reason': 'folder_is_metadata_root',
+                        }
+                    )
+                    continue
+                if not _folder_has_recursive_datasets(child, user):
+                    existing_results.append(
+                        {
+                            'rootFolderId': str(child['_id']),
+                            'reason': 'no_datasets',
+                        }
+                    )
+                    continue
+                metadata_name = _metadata_folder_name_for_dataset_folder(child, name)
+                metadata_folder = _find_existing_dive_metadata_sibling(child, user, metadata_name)
+                if metadata_folder is None:
+                    # Legacy layout: metadata folder was created inside the dataset folder.
+                    metadata_folder = _find_existing_dive_metadata_child(child, user)
+                reused_existing = metadata_folder is not None
+                try:
+                    base_folder = metadata_folder or _create_dive_metadata_sibling_folder(
+                        child, metadata_name, user
+                    )
+                except RestException as exc:
+                    errors.append(f'{child["name"]}: {exc}')
+                    continue
+                populate_result = _populate_dive_metadata_folder(
+                    base_folder,
+                    child,
+                    user,
+                    display_config,
+                    ffprobe_metadata,
+                    categoricalLimit,
+                    replace_metadata=False,
+                )
+                entry = {
+                    'rootFolderId': str(child['_id']),
+                    'metadataFolderId': str(base_folder['_id']),
+                    'added': populate_result['added'],
+                    'existing': populate_result['existing'],
+                }
+                if reused_existing:
+                    entry['reusedExisting'] = True
+                if reused_existing and populate_result['added'] == 0:
+                    existing_results.append({**entry, 'reason': 'existing_metadata_folder'})
+                else:
+                    created.append(entry)
+
+        return {
+            'scope': scope_norm,
+            'resourceType': resource_type,
+            'resourceId': str(resource['_id']),
+            'created': created,
+            'existing': existing_results,
+            'errors': errors,
         }
 
     @access.user

--- a/server/dive_server/views_metadata.py
+++ b/server/dive_server/views_metadata.py
@@ -570,6 +570,23 @@ def _normalize_create_metadata_configs(displayConfig, ffprobeMetadata):
     return display_config, ffprobe_metadata
 
 
+def _display_config_from_metadata_folder(metadata_folder):
+    """Build display config for indexing from an existing DIVE metadata folder."""
+    stored = metadata_folder.get('meta', {}).get(DIVEMetadataFilter) or {}
+    display_config = _normalize_metadata_config(stored, _CREATE_METADATA_DISPLAY_DEFAULT)
+    if stored.get('categoricalLimit') is not None:
+        display_config['categoricalLimit'] = stored['categoricalLimit']
+    return display_config
+
+
+def _categorical_limit_from_metadata_folder(metadata_folder, display_config):
+    return (
+        metadata_folder.get('meta', {})
+        .get(DIVEMetadataFilter, {})
+        .get('categoricalLimit', display_config.get('categoricalLimit', 50))
+    )
+
+
 def _build_default_dataset_metadata_row(item, user, ffprobe_metadata):
     data = {
         'DIVE_DatasetId': str(item['_id']),
@@ -872,6 +889,7 @@ class DIVEMetadata(Resource):
         )
         self.route("POST", ("create_metadata_folder", ":id"), self.create_metadata_folder)
         self.route("POST", ("create_metadata_recursive",), self.create_metadata_recursive)
+        self.route("POST", (":id", "index_folder"), self.index_metadata_folder)
         self.route("POST", (':id', "clone_filter"), self.clone_filter)
         self.route("GET", (':id', 'metadata_keys'), self.get_metadata_keys)
         self.route("GET", (':id', 'metadata_filter_values'), self.get_metadata_filter)
@@ -1434,6 +1452,78 @@ class DIVEMetadata(Resource):
             'created': created,
             'existing': existing_results,
             'errors': errors,
+        }
+
+    @access.user
+    @autoDescribeRoute(
+        Description(
+            "Index DIVE datasets from another folder into an existing DIVE metadata folder. "
+            "Adds rows for datasets not yet in the metadata root; optionally replaces default "
+            "fields for datasets already indexed from the same scan."
+        )
+        .modelParam(
+            "id",
+            description="Existing DIVE metadata folder",
+            model=Folder,
+            level=AccessType.WRITE,
+        )
+        .param(
+            "rootFolderId",
+            "Folder to scan recursively for DIVE datasets to add or refresh",
+            paramType="formData",
+            dataType="string",
+            required=True,
+        )
+        .param(
+            "replaceMetadata",
+            "When true, overwrite default metadata rows for datasets found under rootFolderId",
+            paramType="formData",
+            dataType="boolean",
+            default=False,
+            required=False,
+        )
+        .jsonParam(
+            "ffprobeMetadata",
+            "ffprobe keys to import for newly indexed or replaced rows",
+            required=False,
+            default=_CREATE_METADATA_FFPROBE_DEFAULT,
+        )
+    )
+    def index_metadata_folder(self, folder, rootFolderId, replaceMetadata, ffprobeMetadata):
+        user = self.getCurrentUser()
+        if not _is_dive_metadata_folder(folder):
+            raise RestException('Folder is not a DIVE Metadata folder', code=400)
+        root_folder = Folder().load(
+            rootFolderId,
+            level=AccessType.WRITE,
+            user=user,
+            force=True,
+        )
+        display_config = _display_config_from_metadata_folder(folder)
+        ffprobe_metadata = _normalize_metadata_config(
+            ffprobeMetadata,
+            _CREATE_METADATA_FFPROBE_DEFAULT,
+        )
+        categorical_limit = _categorical_limit_from_metadata_folder(folder, display_config)
+        populate_result = _populate_dive_metadata_folder(
+            folder,
+            root_folder,
+            user,
+            display_config,
+            ffprobe_metadata,
+            categorical_limit,
+            replace_metadata=replaceMetadata is True,
+        )
+        return {
+            'results': (
+                f"indexed {populate_result['datasetCount']} datasets: "
+                f"added {populate_result['added']}, skipped {populate_result['existing']} existing"
+            ),
+            'metadataFolderId': str(folder['_id']),
+            'rootFolderId': str(root_folder['_id']),
+            'added': populate_result['added'],
+            'existing': populate_result['existing'],
+            'datasetCount': populate_result['datasetCount'],
         }
 
     @access.user

--- a/server/dive_utils/metadata/models.py
+++ b/server/dive_utils/metadata/models.py
@@ -46,8 +46,18 @@ class DIVE_Metadata(Model):
             ]
         )
 
-    def createMetadata(self, folder, root, owner, metadata, created_date=None):  # noqa: B006
+    def createMetadata(
+        self,
+        folder,
+        root,
+        owner,
+        metadata,
+        created_date=None,
+        replace=True,
+    ):  # noqa: B006
         existing = self.findOne({'DIVEDataset': str(folder['_id']), 'root': str(root['_id'])})
+        if existing and not replace:
+            return existing
         if not existing:
             if created_date is None:
                 created = datetime.datetime.utcnow()
@@ -254,8 +264,10 @@ class DIVE_MetadataKeys(Model):
                 existing['owner'] = str(user['_id'])
             self.save(existing)
 
-    def createMetadataKeys(self, root, owner, metadataKeys, created_date=None):
+    def createMetadataKeys(self, root, owner, metadataKeys, created_date=None, replace=True):
         existing = self.findOne({'root': str(root['_id'])})
+        if existing and not replace:
+            return existing
         if not existing:
             if created_date is None:
                 created = datetime.datetime.utcnow()

--- a/server/tests/test_process_metadata_helpers.py
+++ b/server/tests/test_process_metadata_helpers.py
@@ -14,6 +14,8 @@ from dive_server.views_metadata import (  # noqa: E402
     _PROCESS_METADATA_DISPLAY_DEFAULT,
     _PROCESS_METADATA_FFPROBE_DEFAULT,
     _accumulate_flat_metadata_key_stats,
+    _categorical_limit_from_metadata_folder,
+    _display_config_from_metadata_folder,
     _finalize_metadata_keys_categories,
     _is_blank_metadata_value_for_stats,
     _is_dive_metadata_folder,
@@ -23,6 +25,7 @@ from dive_server.views_metadata import (  # noqa: E402
     _normalize_metadata_config,
     remove_before_folder,
 )
+from dive_utils.constants import DIVEMetadataFilter  # noqa: E402
 
 
 @pytest.mark.parametrize(
@@ -55,6 +58,22 @@ def test_metadata_folder_name_for_dataset_folder():
     assert _metadata_folder_name_for_dataset_folder({'name': 'Study A'}, 'DIVE Metadata') == (
         'Study A - DIVE Metadata'
     )
+
+
+def test_display_config_from_metadata_folder_uses_stored_filter():
+    folder = {
+        'meta': {
+            DIVEMetadataFilter: {
+                'display': ['Species'],
+                'hide': ['DIVE_Path'],
+                'categoricalLimit': 25,
+            },
+        },
+    }
+    display_config = _display_config_from_metadata_folder(folder)
+    assert display_config['display'] == ['Species']
+    assert display_config['hide'] == ['DIVE_Path']
+    assert _categorical_limit_from_metadata_folder(folder, display_config) == 25
 
 
 def test_normalize_metadata_config_none_uses_defaults():

--- a/server/tests/test_process_metadata_helpers.py
+++ b/server/tests/test_process_metadata_helpers.py
@@ -16,6 +16,8 @@ from dive_server.views_metadata import (  # noqa: E402
     _accumulate_flat_metadata_key_stats,
     _finalize_metadata_keys_categories,
     _is_blank_metadata_value_for_stats,
+    _is_dive_metadata_folder,
+    _metadata_folder_name_for_dataset_folder,
     _merge_recomputed_metadata_key_stats_into_existing,
     _metadata_dict_for_schema_stats_refresh,
     _normalize_metadata_config,
@@ -34,6 +36,25 @@ def test_remove_before_folder_non_string_returns_none(path):
 def test_remove_before_folder_string_slice():
     assert remove_before_folder('/root/foo/bar', 'foo') == 'foo/bar'
     assert remove_before_folder('/no/match', 'zzz') is None
+
+
+@pytest.mark.parametrize(
+    'meta,expected',
+    [
+        ({'DIVEMetadata': True}, True),
+        ({'DIVEMetadata': 'true'}, True),
+        ({'DIVEMetadata': False}, False),
+        ({}, False),
+    ],
+)
+def test_is_dive_metadata_folder(meta, expected):
+    assert _is_dive_metadata_folder({'meta': meta}) is expected
+
+
+def test_metadata_folder_name_for_dataset_folder():
+    assert _metadata_folder_name_for_dataset_folder({'name': 'Study A'}, 'DIVE Metadata') == (
+        'Study A - DIVE Metadata'
+    )
 
 
 def test_normalize_metadata_config_none_uses_defaults():


### PR DESCRIPTION
resolves #435 

- Adds a scripts/assetStoreImport folder and scripts for creating a MinIO tool for asset store importing and creation of complicated structures of data
- Adds some recursive metadata functionality so metadata can be made either at a single folder level where it will group all folders or for each subfolder in the current folder
    - If made for each subfolder it will name it ` "{folderName} - 'DIVE Metadata"` or whatever template string you choose
- Support for creating of DIVE Metadata folders at the root level of a collection
    - This can either be a recursive lookup for all folders or it can be a DIVE Metadata folder per existing top-level folder
- UI options for choosing between a single folder or multiple DIVE Metadata folders when creating a folder in the interface
- Added the ability to re-index or add other dataets to a current DIVEMetadata folder