### PR TITLE
Metadata create import sub metadata option

### DIFF
--- a/client/dive-common/vue-utilities/prompt-service/Prompt.vue
+++ b/client/dive-common/vue-utilities/prompt-service/Prompt.vue
@@ -142,6 +142,7 @@ export default defineComponent({
 <template>
   <v-dialog
     v-model="show"
+    content-class="theme--dark"
     :max-width="maxWidth"
   >
     <v-card>

--- a/client/dive-common/vue-utilities/prompt-service/index.ts
+++ b/client/dive-common/vue-utilities/prompt-service/index.ts
@@ -158,7 +158,9 @@ export default function (vuetify: Vuetify) {
 
     Vue.prototype.$promptAttach = function () {
       const div = document.createElement('div');
-      this.$el.appendChild(div);
+      // Mount outside the app tree so dialogs are not affected by app layout
+      // (overflow / sticky / transform containing blocks).
+      document.body.appendChild(div);
       if (promptService) {
         promptService.mount(div);
       }

--- a/client/platform/web-girder/App.vue
+++ b/client/platform/web-girder/App.vue
@@ -65,7 +65,6 @@ export default defineComponent({
 <style lang="scss">
 html {
   overflow-y: auto;
-  transform-style: preserve-3d;
 }
 
 .text-xs-center {

--- a/client/platform/web-girder/api/divemetadata.service.ts
+++ b/client/platform/web-girder/api/divemetadata.service.ts
@@ -195,9 +195,12 @@ export interface createDiveMetadataResponse {
   'results': string,
   'errors': string[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  'metadataKeys': any[];
+  'metadataKeys': any[] | Record<string, unknown>;
   'folderId': string;
   existing?: number;
+  added?: number;
+  metadataFoldersFound?: number;
+  combineMetadataFolders?: boolean;
 }
 
 export interface CreateDiveMetadataRecursiveEntry {
@@ -225,6 +228,8 @@ export interface IndexDiveMetadataFolderResponse {
   added: number;
   existing: number;
   datasetCount: number;
+  metadataFoldersFound: number;
+  combineMetadataFolders: boolean;
 }
 
 function createDiveMetadataFolder(
@@ -232,6 +237,7 @@ function createDiveMetadataFolder(
   name: string,
   rootFolderId: string,
   categoricalLimit = 50,
+  combineMetadataFolders = false,
   displayConfig = {
     display: ['DIVE_DatasetId', 'DIVE_Name'],
   },
@@ -244,6 +250,7 @@ function createDiveMetadataFolder(
       name,
       rootFolderId,
       categoricalLimit,
+      combineMetadataFolders,
       displayConfig: toJsonParam(displayConfig),
       ffprobeMetadata: toJsonParam(ffprobeMetadata),
     },
@@ -282,6 +289,7 @@ function indexDiveMetadataFromFolder(
   metadataFolderId: string,
   rootFolderId: string,
   replaceMetadata = false,
+  combineMetadataFolders = false,
   ffprobeMetadata = {
     import: true, keys: ['width', 'height', 'display_aspect_ratio', 'nb_frames', 'duration'],
   },
@@ -293,6 +301,7 @@ function indexDiveMetadataFromFolder(
       params: {
         rootFolderId,
         replaceMetadata,
+        combineMetadataFolders,
         ffprobeMetadata: toJsonParam(ffprobeMetadata),
       },
     },

--- a/client/platform/web-girder/views/CreateDIVEMetadata.vue
+++ b/client/platform/web-girder/views/CreateDIVEMetadata.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  computed, defineComponent, Ref, ref, PropType,
+  computed, defineComponent, Ref, ref, PropType, watch,
 } from 'vue';
 import { GirderFileManager, GirderModelType } from '@girder/components/src';
 import useRequest from 'dive-common/use/useRequest';
@@ -12,6 +12,7 @@ import {
   createDiveMetadataFolder,
   createDiveMetadataRecursive,
 } from 'platform/web-girder/api/divemetadata.service';
+import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import eventBus from '../eventBus';
 import type { GirderModel } from 'vue-girder-slicer-cli-ui/dist/girderTypes';
 
@@ -48,10 +49,12 @@ export default defineComponent({
   setup(props) {
     const router = useRouter();
     const girderRest = useGirderRest();
+    const { prompt } = usePrompt();
     const source = ref(null as GirderModel | { _id: string; _modelType: string; name: string } | null);
     const open = ref(false);
     const categoricalLimit = ref(50);
     const perSubfolder = ref(false);
+    const combineMetadataFolders = ref(false);
     const scope = ref<'single' | 'subfolders'>('single');
     const location: Ref<RootlessLocationType> = ref({
       _modelType: ('user' as GirderModelType),
@@ -71,6 +74,18 @@ export default defineComponent({
       return perSubfolder.value ? 'subfolders' : 'single';
     });
 
+    watch(useRecursiveApi, (recursive) => {
+      if (recursive) {
+        combineMetadataFolders.value = false;
+      }
+    });
+
+    watch(combineMetadataFolders, (combine) => {
+      if (combine) {
+        perSubfolder.value = false;
+      }
+    });
+
     async function click() {
       if (!props.datasetId) {
         return;
@@ -83,12 +98,14 @@ export default defineComponent({
         };
         scope.value = 'subfolders';
         perSubfolder.value = true;
+        combineMetadataFolders.value = false;
         newName.value = 'DIVE Metadata';
       } else {
         source.value = (await getFolder(props.datasetId)).data;
         newName.value = `DiveMetadata of ${source.value.name}`;
         scope.value = 'single';
         perSubfolder.value = false;
+        combineMetadataFolders.value = false;
       }
       open.value = true;
     }
@@ -140,9 +157,22 @@ export default defineComponent({
         newName.value,
         props.datasetId,
         categoricalLimit.value,
+        combineMetadataFolders.value,
       );
-      router.push({ name: 'metadata', params: { id: newDataset.data.folderId } });
+      const folderId = newDataset.data.folderId;
       open.value = false;
+      if (combineMetadataFolders.value) {
+        await prompt({
+          title: 'DIVE Metadata folders combined',
+          text: [
+            `DIVE Metadata folders found: ${newDataset.data.metadataFoldersFound ?? 0}`,
+            `Datasets added: ${newDataset.data.added ?? 0}`,
+            `Datasets skipped (already present): ${newDataset.data.existing ?? 0}`,
+          ],
+          positiveButton: 'OK',
+        });
+      }
+      router.push({ name: 'metadata', params: { id: folderId } });
     });
 
     return {
@@ -155,6 +185,7 @@ export default defineComponent({
       source,
       categoricalLimit,
       perSubfolder,
+      combineMetadataFolders,
       scope,
       isCollection,
       useRecursiveApi,
@@ -215,6 +246,11 @@ export default defineComponent({
             collection or one per top-level folder (as a sibling folder next to each one). Existing
             metadata folders are reused and only missing datasets are indexed.
           </p>
+          <p v-else-if="combineMetadataFolders">
+            Recursively find DIVE Metadata folders under the current folder and merge all of their
+            datasets and columns into a new metadata collection. Existing metadata rows are not
+            replaced.
+          </p>
           <p v-else>
             This indexes DIVE datasets under the current folder. Existing metadata rows are not
             replaced. Choose a destination folder, or enable per-subfolder creation below.
@@ -248,12 +284,21 @@ export default defineComponent({
               value="subfolders"
             />
           </v-radio-group>
-          <v-checkbox
-            v-else
-            v-model="perSubfolder"
-            label="Create a sibling metadata folder for each immediate subfolder"
-            class="mt-2"
-          />
+          <template v-else>
+            <v-checkbox
+              v-model="combineMetadataFolders"
+              label="Only combine nested DIVE Metadata folders"
+              :disabled="createLoading"
+              hide-details
+              class="mt-2"
+            />
+            <v-checkbox
+              v-model="perSubfolder"
+              label="Create a sibling metadata folder for each immediate subfolder"
+              :disabled="createLoading || combineMetadataFolders"
+              class="mt-2"
+            />
+          </template>
 
           <v-card
             v-if="!useRecursiveApi"
@@ -279,6 +324,15 @@ export default defineComponent({
                 >
                   dataset
                 </v-chip>
+                <v-chip
+                  v-if="(item.meta && item.meta.DIVEMetadata)"
+                  color="primary"
+                  x-small
+                  outlined
+                  class="mx-3"
+                >
+                  metadata
+                </v-chip>
               </template>
             </GirderFileManager>
           </v-card>
@@ -299,6 +353,9 @@ export default defineComponent({
             </span>
             <span v-else-if="useRecursiveApi">
               Create metadata for {{ source.name }}
+            </span>
+            <span v-else-if="'name' in location && combineMetadataFolders">
+              Combine DIVE Metadata into folder in {{ location.name }}
             </span>
             <span v-else-if="'name' in location">
               Create metadata folder in {{ location.name }}

--- a/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataIndexFolder.vue
+++ b/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataIndexFolder.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  computed, defineComponent, Ref, ref,
+  computed, defineComponent, nextTick, Ref, ref,
 } from 'vue';
 import { GirderFileManager, GirderModelType } from '@girder/components/src';
 import useRequest from 'dive-common/use/useRequest';
@@ -39,6 +39,7 @@ export default defineComponent({
     const { prompt } = usePrompt();
     const open = ref(false);
     const replaceMetadata = ref(false);
+    const combineMetadataFolders = ref(false);
     const location: Ref<RootlessLocationType> = ref({
       _modelType: ('user' as GirderModelType),
       _id: girderRest.user._id,
@@ -60,12 +61,24 @@ export default defineComponent({
         props.metadataRoot,
         location.value._id,
         replaceMetadata.value,
+        combineMetadataFolders.value,
       );
       open.value = false;
       emit('updated');
+      const statusLines = combineMetadataFolders.value
+        ? [
+          `DIVE Metadata folders found: ${data.metadataFoldersFound}`,
+          `Datasets added: ${data.added}`,
+          `Datasets skipped (already present): ${data.existing}`,
+        ]
+        : [data.results];
+      // Let the index dialog finish closing before opening the status prompt.
+      await nextTick();
       await prompt({
-        title: 'Folder indexed',
-        text: [data.results],
+        title: combineMetadataFolders.value
+          ? 'DIVE Metadata folders combined'
+          : 'Folder indexed',
+        text: statusLines,
         positiveButton: 'OK',
       });
     });
@@ -73,6 +86,7 @@ export default defineComponent({
     return {
       open,
       replaceMetadata,
+      combineMetadataFolders,
       location,
       locationIsFolder,
       indexLoading,
@@ -123,37 +137,66 @@ export default defineComponent({
         >
           {{ indexError }}
         </v-alert>
-        <p>
+        <p v-if="!combineMetadataFolders">
           Scan a Girder folder (and its subfolders) for DIVE datasets and add them to this
           metadata collection. Datasets already in the collection are skipped unless you enable
           replace below.
         </p>
+        <p v-else>
+          Recursively find DIVE Metadata folders under the selected folder and merge all of their
+          datasets and columns into this collection. Datasets already present are skipped unless
+          you enable replace below.
+        </p>
         <v-checkbox
-          v-model="replaceMetadata"
-          label="Replace default metadata for datasets found in this folder"
+          v-model="combineMetadataFolders"
+          label="Only combine nested DIVE Metadata folders"
           :disabled="indexLoading || readOnlyMode"
           hide-details
           class="mb-2"
         />
-        <GirderFileManager
-          new-folder-enabled
-          no-access-control-w
-          :location="location"
-          @update:location="setLocation"
+        <v-checkbox
+          v-model="replaceMetadata"
+          :label="combineMetadataFolders
+            ? 'Replace existing rows with metadata from source folders'
+            : 'Replace default metadata for datasets found in this folder'"
+          :disabled="indexLoading || readOnlyMode"
+          hide-details
+          class="mb-2"
+        />
+        <v-card
+          outlined
+          flat
+          class="mt-2"
         >
-          <template #row="{ item }">
-            <span>{{ item.name }}</span>
-            <v-chip
-              v-if="(item.meta && item.meta.annotate)"
-              color="white"
-              x-small
-              outlined
-              class="mx-3"
-            >
-              dataset
-            </v-chip>
-          </template>
-        </GirderFileManager>
+          <GirderFileManager
+            new-folder-enabled
+            no-access-control-w
+            :location="location"
+            @update:location="setLocation"
+          >
+            <template #row="{ item }">
+              <span>{{ item.name }}</span>
+              <v-chip
+                v-if="(item.meta && item.meta.annotate)"
+                color="white"
+                x-small
+                outlined
+                class="mx-3"
+              >
+                dataset
+              </v-chip>
+              <v-chip
+                v-if="(item.meta && item.meta.DIVEMetadata)"
+                color="primary"
+                x-small
+                outlined
+                class="mx-3"
+              >
+                metadata
+              </v-chip>
+            </template>
+          </GirderFileManager>
+        </v-card>
         <v-btn
           depressed
           block
@@ -165,6 +208,9 @@ export default defineComponent({
         >
           <span v-if="!locationIsFolder">
             Choose a folder...
+          </span>
+          <span v-else-if="'name' in location && combineMetadataFolders">
+            Combine DIVE Metadata under {{ location.name }}
           </span>
           <span v-else-if="'name' in location">
             Index datasets under {{ location.name }}

--- a/docs/DIVE-Metadata.md
+++ b/docs/DIVE-Metadata.md
@@ -69,6 +69,14 @@ A new collection of URL endpoints under `dive_metadata` allows for importing and
 
 Creates a DIVE metadata folder under `parentFolderId` and indexes datasets under `rootFolderId`. If a metadata folder already exists under the parent, it is reused. Existing per-dataset metadata rows are not overwritten.
 
+| Parameter | Description |
+|-----------|-------------|
+| `name` | Metadata folder name |
+| `rootFolderId` | Folder to scan for DIVE datasets (or nested DIVE metadata folders when combining) |
+| `categoricalLimit` | Unique-value threshold before a string field becomes search instead of categorical |
+| `displayConfig` / `ffprobeMetadata` | Display layout and optional ffprobe key import |
+| `combineMetadataFolders` | When `true` (default `false`), only recursively find nested **DIVE Metadata** folders and merge their dataset rows and columns (does not index bare datasets). Response includes `metadataFoldersFound` and `added`. |
+
 **POST** `/dive_metadata/create_metadata_recursive`
 
 Creates metadata for a Girder **folder** or **collection** without replacing existing metadata.
@@ -92,11 +100,14 @@ Indexes DIVE datasets from a Girder folder into an **existing** DIVE metadata fo
 
 | Parameter | Description |
 |-----------|-------------|
-| `rootFolderId` | Folder to scan recursively for DIVE datasets |
-| `replaceMetadata` | When `true`, overwrite default metadata rows (`DIVE_*`, ffprobe fields) for datasets found under `rootFolderId`; custom keys from CSV/JSON import are unchanged unless you re-import those files |
-| `ffprobeMetadata` | Same object as `create_metadata_folder` (optional) |
+| `rootFolderId` | Folder to scan recursively for DIVE datasets (or nested DIVE metadata folders when combining) |
+| `replaceMetadata` | When `true`, overwrite metadata rows for datasets found under `rootFolderId` (default `DIVE_*` / ffprobe fields in dataset mode; full source rows in combine mode) |
+| `combineMetadataFolders` | When `true`, only recursively find nested **DIVE Metadata** folders and merge all of their dataset rows and columns into this collection (does not index bare datasets) |
+| `ffprobeMetadata` | Same object as `create_metadata_folder` (optional; ignored when `combineMetadataFolders` is true) |
 
 Only datasets not yet in the metadata root are added by default. Use this after importing new media into a sibling or child folder, or to attach a second dataset tree to one metadata collection.
+
+When `combineMetadataFolders` is true, the response includes `metadataFoldersFound` (count of source DIVE Metadata folders) and `added` (datasets merged into the target).
 
 ### Ingesting DIVE Metadata
 

--- a/server/dive_server/views_metadata.py
+++ b/server/dive_server/views_metadata.py
@@ -685,6 +685,155 @@ def _populate_dive_metadata_folder(
     }
 
 
+def _get_recursive_dive_metadata_folders(
+    folder,
+    user,
+    results,
+    skip_ids=None,
+):
+    """
+    Recursively collect Girder folders marked as DIVE metadata under ``folder``.
+
+    Includes ``folder`` itself when it is a DIVE metadata folder. Skip ids in
+    ``skip_ids`` (e.g. the destination metadata root being combined into).
+    """
+    skip = {str(sid) for sid in (skip_ids or [])}
+    folder_id = str(folder['_id'])
+    if folder_id not in skip and _is_dive_metadata_folder(folder):
+        results.append(folder)
+    for child in Folder().childFolders(folder, 'folder', user=user):
+        _get_recursive_dive_metadata_folders(child, user, results, skip_ids=skip)
+
+
+def _combine_dive_metadata_folders(
+    base_folder,
+    root_folder,
+    user,
+    display_config,
+    categorical_limit,
+    replace_metadata=False,
+):
+    """
+    Find nested DIVE metadata folders under ``root_folder`` and merge their rows
+    (full metadata dicts / columns) into ``base_folder``.
+
+    Does not scan for bare DIVE datasets — only folders marked as DIVE metadata.
+    """
+    target_id = str(base_folder['_id'])
+    source_folders = []
+    _get_recursive_dive_metadata_folders(
+        root_folder,
+        user,
+        source_folders,
+        skip_ids={target_id},
+    )
+
+    added = 0
+    existing_count = 0
+    datasets_seen = set()
+    key_descriptions = {}
+    unlocked_keys = set()
+
+    for source_folder in source_folders:
+        source_root = str(source_folder['_id'])
+        source_keys_doc = DIVE_MetadataKeys().findOne({'root': source_root})
+        if source_keys_doc:
+            for key, bucket in (source_keys_doc.get('metadataKeys') or {}).items():
+                desc = bucket.get('description') if isinstance(bucket, dict) else None
+                if (
+                    isinstance(desc, str)
+                    and desc.strip()
+                    and key not in key_descriptions
+                ):
+                    key_descriptions[key] = desc.strip()
+            for unlocked_key in source_keys_doc.get('unlocked') or []:
+                unlocked_keys.add(unlocked_key)
+
+        for row in DIVE_Metadata().find({'root': source_root}):
+            dataset_id = str(row.get('DIVEDataset') or '')
+            if not dataset_id:
+                continue
+            if dataset_id in datasets_seen and not replace_metadata:
+                continue
+
+            existing_row = DIVE_Metadata().findOne(
+                {'DIVEDataset': dataset_id, 'root': target_id}
+            )
+            if existing_row and not replace_metadata:
+                existing_count += 1
+                datasets_seen.add(dataset_id)
+                continue
+
+            dataset_folder = Folder().load(
+                dataset_id,
+                level=AccessType.READ,
+                user=user,
+                force=True,
+            )
+            if dataset_folder is None:
+                continue
+
+            data = dict(row.get('metadata') or {})
+            data['DIVE_DatasetId'] = dataset_id
+            data['DIVE_Name'] = str(
+                dataset_folder.get('lowerName', dataset_folder.get('name', ''))
+            )
+            data['DIVE_Path'] = path_util.getResourcePath(
+                'folder', dataset_folder, user=user
+            )
+            sanitize_value_tree_for_girder_json(data, minmax_keys_to_zero=False)
+            DIVE_Metadata().createMetadata(
+                dataset_folder,
+                base_folder,
+                user,
+                data,
+                replace=replace_metadata or existing_row is None,
+            )
+            added += 1
+            datasets_seen.add(dataset_id)
+
+    keys_doc = DIVE_MetadataKeys().findOne({'root': target_id})
+    if keys_doc is None:
+        DIVE_MetadataKeys().createMetadataKeys(base_folder, user, {}, replace=True)
+    if added > 0 or keys_doc is None:
+        refresh_metadata_keys_stats_from_stored_dive_metadata(
+            base_folder, categorical_limit
+        )
+
+    if key_descriptions:
+        try:
+            DIVE_MetadataKeys().mergeImportedKeyDescriptions(
+                base_folder, user, key_descriptions
+            )
+        except Exception:
+            # Destination owner checks may block description merge for non-owners;
+            # row/column data is already combined.
+            pass
+
+    if unlocked_keys:
+        dest_keys = DIVE_MetadataKeys().findOne({'root': target_id})
+        if dest_keys is not None:
+            current_unlocked = list(dest_keys.get('unlocked') or [])
+            changed = False
+            for key in unlocked_keys:
+                if key in (dest_keys.get('metadataKeys') or {}) and key not in current_unlocked:
+                    current_unlocked.append(key)
+                    changed = True
+            if changed:
+                dest_keys['unlocked'] = current_unlocked
+                DIVE_MetadataKeys().save(dest_keys)
+
+    if not _is_dive_metadata_folder(base_folder):
+        _apply_dive_metadata_folder_marker(base_folder, display_config, categorical_limit)
+
+    return {
+        'metadataFoldersFound': len(source_folders),
+        'added': added,
+        'existing': existing_count,
+        'datasetCount': len(datasets_seen),
+    }
+
+
 def _resolve_create_metadata_targets(resource_id, resource_type, user):
     if resource_type == 'collection':
         collection = Collection().load(
@@ -1167,7 +1316,11 @@ class DIVEMetadata(Resource):
 
     @access.user
     @autoDescribeRoute(
-        Description("Processing a folder and any children folder that have a specified format")
+        Description(
+            "Create a DIVE metadata folder under a parent and index datasets under rootFolderId. "
+            "When combineMetadataFolders is true, only nested DIVE metadata folders are merged "
+            "(full rows and columns), not bare datasets."
+        )
         .modelParam(
             "id",
             description="Parent Folder of where to add the new metadata folder",
@@ -1200,7 +1353,8 @@ class DIVEMetadata(Resource):
         )
         .jsonParam(
             "ffprobeMetadata",
-            "List Metadata keys to extract from the ffprobe metadata from videos.  Setting 'import' to 'true' will import the data",
+            "List Metadata keys to extract from the ffprobe metadata from videos.  Setting 'import' to 'true' will import the data "
+            "(ignored when combineMetadataFolders is true)",
             required=True,
             default={
                 "import": True,
@@ -1214,9 +1368,25 @@ class DIVEMetadata(Resource):
             dataType="integer",
             default=50,
         )
+        .param(
+            "combineMetadataFolders",
+            "When true, recursively find DIVE metadata folders under rootFolderId and merge "
+            "all of their dataset rows and columns into the new metadata collection",
+            paramType="formData",
+            dataType="boolean",
+            default=False,
+            required=False,
+        )
     )
     def create_metadata_folder(
-        self, folder, name, rootFolderId, displayConfig, ffprobeMetadata, categoricalLimit
+        self,
+        folder,
+        name,
+        rootFolderId,
+        displayConfig,
+        ffprobeMetadata,
+        categoricalLimit,
+        combineMetadataFolders,
     ):
         user = self.getCurrentUser()
         metadata_folder = _find_existing_dive_metadata_child(folder, user)
@@ -1231,6 +1401,33 @@ class DIVEMetadata(Resource):
             displayConfig,
             ffprobeMetadata,
         )
+        combine = combineMetadataFolders is True
+
+        if combine:
+            populate_result = _combine_dive_metadata_folders(
+                base_folder,
+                root_folder,
+                user,
+                display_config,
+                categoricalLimit,
+                replace_metadata=False,
+            )
+            added = populate_result['added']
+            metadata_folders_found = populate_result['metadataFoldersFound']
+            return {
+                "results": (
+                    f"found {metadata_folders_found} DIVE Metadata folders; "
+                    f"added {added} datasets, skipped {populate_result['existing']} existing"
+                ),
+                "errors": [],
+                "metadataKeys": {},
+                "folderId": str(base_folder['_id']),
+                "existing": populate_result['existing'],
+                "added": added,
+                "metadataFoldersFound": metadata_folders_found,
+                "combineMetadataFolders": True,
+            }
+
         populate_result = _populate_dive_metadata_folder(
             base_folder,
             root_folder,
@@ -1248,6 +1445,9 @@ class DIVEMetadata(Resource):
             "metadataKeys": populate_result['metadataKeys'],
             "folderId": str(base_folder['_id']),
             "existing": populate_result['existing'],
+            "added": added,
+            "metadataFoldersFound": 0,
+            "combineMetadataFolders": False,
         }
 
     @access.user
@@ -1470,7 +1670,9 @@ class DIVEMetadata(Resource):
         Description(
             "Index DIVE datasets from another folder into an existing DIVE metadata folder. "
             "Adds rows for datasets not yet in the metadata root; optionally replaces default "
-            "fields for datasets already indexed from the same scan."
+            "fields for datasets already indexed from the same scan. "
+            "When combineMetadataFolders is true, only nested DIVE metadata folders are merged "
+            "(full rows and columns), not bare datasets."
         )
         .modelParam(
             "id",
@@ -1480,14 +1682,24 @@ class DIVEMetadata(Resource):
         )
         .param(
             "rootFolderId",
-            "Folder to scan recursively for DIVE datasets to add or refresh",
+            "Folder to scan recursively for DIVE datasets (or DIVE metadata folders when combining)",
             paramType="formData",
             dataType="string",
             required=True,
         )
         .param(
             "replaceMetadata",
-            "When true, overwrite default metadata rows for datasets found under rootFolderId",
+            "When true, overwrite metadata rows for datasets found under rootFolderId "
+            "(default fields in dataset mode; full source rows in combine mode)",
+            paramType="formData",
+            dataType="boolean",
+            default=False,
+            required=False,
+        )
+        .param(
+            "combineMetadataFolders",
+            "When true, recursively find DIVE metadata folders under rootFolderId and merge "
+            "all of their dataset rows and columns into this metadata collection",
             paramType="formData",
             dataType="boolean",
             default=False,
@@ -1495,12 +1707,20 @@ class DIVEMetadata(Resource):
         )
         .jsonParam(
             "ffprobeMetadata",
-            "ffprobe keys to import for newly indexed or replaced rows",
+            "ffprobe keys to import for newly indexed or replaced rows "
+            "(ignored when combineMetadataFolders is true)",
             required=False,
             default=_CREATE_METADATA_FFPROBE_DEFAULT,
         )
     )
-    def index_metadata_folder(self, folder, rootFolderId, replaceMetadata, ffprobeMetadata):
+    def index_metadata_folder(
+        self,
+        folder,
+        rootFolderId,
+        replaceMetadata,
+        combineMetadataFolders,
+        ffprobeMetadata,
+    ):
         user = self.getCurrentUser()
         if not _is_dive_metadata_folder(folder):
             raise RestException('Folder is not a DIVE Metadata folder', code=400)
@@ -1511,11 +1731,39 @@ class DIVEMetadata(Resource):
             force=True,
         )
         display_config = _display_config_from_metadata_folder(folder)
+        categorical_limit = _categorical_limit_from_metadata_folder(folder, display_config)
+        combine = combineMetadataFolders is True
+        replace = replaceMetadata is True
+
+        if combine:
+            populate_result = _combine_dive_metadata_folders(
+                folder,
+                root_folder,
+                user,
+                display_config,
+                categorical_limit,
+                replace_metadata=replace,
+            )
+            metadata_folders_found = populate_result['metadataFoldersFound']
+            return {
+                'results': (
+                    f"found {metadata_folders_found} DIVE Metadata folders; "
+                    f"added {populate_result['added']} datasets, "
+                    f"skipped {populate_result['existing']} existing"
+                ),
+                'metadataFolderId': str(folder['_id']),
+                'rootFolderId': str(root_folder['_id']),
+                'added': populate_result['added'],
+                'existing': populate_result['existing'],
+                'datasetCount': populate_result['datasetCount'],
+                'metadataFoldersFound': metadata_folders_found,
+                'combineMetadataFolders': True,
+            }
+
         ffprobe_metadata = _normalize_metadata_config(
             ffprobeMetadata,
             _CREATE_METADATA_FFPROBE_DEFAULT,
         )
-        categorical_limit = _categorical_limit_from_metadata_folder(folder, display_config)
         populate_result = _populate_dive_metadata_folder(
             folder,
             root_folder,
@@ -1523,7 +1771,7 @@ class DIVEMetadata(Resource):
             display_config,
             ffprobe_metadata,
             categorical_limit,
-            replace_metadata=replaceMetadata is True,
+            replace_metadata=replace,
         )
         return {
             'results': (
@@ -1535,6 +1783,8 @@ class DIVEMetadata(Resource):
             'added': populate_result['added'],
             'existing': populate_result['existing'],
             'datasetCount': populate_result['datasetCount'],
+            'metadataFoldersFound': 0,
+            'combineMetadataFolders': False,
         }
 
     @access.user

--- a/server/tests/test_process_metadata_helpers.py
+++ b/server/tests/test_process_metadata_helpers.py
@@ -17,6 +17,7 @@ from dive_server.views_metadata import (  # noqa: E402
     _categorical_limit_from_metadata_folder,
     _display_config_from_metadata_folder,
     _finalize_metadata_keys_categories,
+    _get_recursive_dive_metadata_folders,
     _is_blank_metadata_value_for_stats,
     _is_dive_metadata_folder,
     _metadata_folder_name_for_dataset_folder,
@@ -178,3 +179,43 @@ def test_merge_recomputed_metadata_key_stats_matches_process_metadata_shape():
     assert merged['note']['set'] == []
     assert merged['note']['unique'] == 0
     assert merged['note']['description'] == 'kept'
+
+
+def test_get_recursive_dive_metadata_folders_finds_nested_and_skips_target(monkeypatch):
+    """Walk a small folder tree and collect DIVEMetadata folders, skipping the destination."""
+    root = {'_id': 'root', 'meta': {}}
+    meta_a = {'_id': 'meta-a', 'meta': {'DIVEMetadata': True}}
+    plain = {'_id': 'plain', 'meta': {}}
+    meta_b = {'_id': 'meta-b', 'meta': {'DIVEMetadata': True}}
+    target = {'_id': 'target', 'meta': {'DIVEMetadata': True}}
+    children = {
+        'root': [meta_a, plain, target],
+        'meta-a': [],
+        'plain': [meta_b],
+        'meta-b': [],
+        'target': [],
+    }
+
+    class FakeFolder:
+        def childFolders(self, folder, _parent_type, user=None):
+            return list(children.get(str(folder['_id']), []))
+
+    monkeypatch.setattr('dive_server.views_metadata.Folder', FakeFolder)
+
+    found = []
+    _get_recursive_dive_metadata_folders(root, user=None, results=found, skip_ids={'target'})
+    assert [f['_id'] for f in found] == ['meta-a', 'meta-b']
+
+
+def test_get_recursive_dive_metadata_folders_includes_root_when_marked(monkeypatch):
+    root = {'_id': 'meta-root', 'meta': {'DIVEMetadata': True}}
+
+    class FakeFolder:
+        def childFolders(self, folder, _parent_type, user=None):
+            return []
+
+    monkeypatch.setattr('dive_server.views_metadata.Folder', FakeFolder)
+
+    found = []
+    _get_recursive_dive_metadata_folders(root, user=None, results=found)
+    assert [f['_id'] for f in found] == ['meta-root']


### PR DESCRIPTION
resolves #484 

This adds an option when creating or indexing a folder for DIVEMetadata.  That option will enable the ability to combine and merge together all of the sub DIVEMetadata fields instead of looking specifically at the DIVEDatasets.  It means you could have several DIVEMetadata folders and use a parent folder and create a single folder that combines all of them for searchability.

- implements back-end tools for searching and combining DIVEMetadata recursively
- Updates the endpoints used to add the option
- Updates UI to have checkboxes to enable this functionality
- Modification to prompt to properly center dialogs on the window and not on the element they are attached to.